### PR TITLE
Add __repr__ and __eq__ to SafetyResult dataclass

### DIFF
--- a/landmarkdiff/safety.py
+++ b/landmarkdiff/safety.py
@@ -41,6 +41,26 @@ class SafetyResult:
     checks: dict[str, bool] = field(default_factory=dict)
     details: dict[str, object] = field(default_factory=dict)
 
+    def __repr__(self) -> str:
+        return (
+            f"SafetyResult(passed={self.passed}, "
+            f"failures={self.failures}, "
+            f"warnings={self.warnings}, "
+            f"checks={self.checks}, "
+            f"details={self.details})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SafetyResult):
+            return NotImplemented
+        return (
+            self.passed == other.passed
+            and self.failures == other.failures
+            and self.warnings == other.warnings
+            and self.checks == other.checks
+            and self.details == other.details
+        )
+
     def add_failure(self, name: str, message: str) -> None:
         self.passed = False
         self.failures.append(message)


### PR DESCRIPTION
Fixes #228

## Changes
- Implement `__repr__` for better debugging and logging
- Implement `__eq__` for proper equality comparison
- Both methods follow Python dataclass best practices

## Testing
- `__repr__` returns a clear string representation of the object
- `__eq__` properly compares all fields including lists and dicts