### PR TITLE
Add file logging handler option to log.py setup_logging()

### DIFF
--- a/landmarkdiff/log.py
+++ b/landmarkdiff/log.py
@@ -26,6 +26,7 @@ def setup_logging(
     level: str | int = "INFO",
     fmt: str | None = None,
     stream: object = None,
+    log_file: str | None = None,
 ) -> None:
     """Configure logging for the landmarkdiff package.
 
@@ -35,6 +36,7 @@ def setup_logging(
         level: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
         fmt: Custom format string. None uses the default.
         stream: Output stream. None defaults to stderr.
+        log_file: Optional file path for logging to a file.
     """
     global _CONFIGURED
 
@@ -45,14 +47,22 @@ def setup_logging(
     root_logger.setLevel(level)
 
     if not _CONFIGURED:
-        handler = logging.StreamHandler(stream or sys.stderr)
-        handler.setFormatter(
-            logging.Formatter(
-                fmt or LOG_FORMAT,
-                datefmt=LOG_DATE_FORMAT,
-            )
+        formatter = logging.Formatter(
+            fmt or LOG_FORMAT,
+            datefmt=LOG_DATE_FORMAT,
         )
-        root_logger.addHandler(handler)
+        
+        # Add stream handler
+        stream_handler = logging.StreamHandler(stream or sys.stderr)
+        stream_handler.setFormatter(formatter)
+        root_logger.addHandler(stream_handler)
+        
+        # Add file handler if log_file is specified
+        if log_file:
+            file_handler = logging.FileHandler(log_file)
+            file_handler.setFormatter(formatter)
+            root_logger.addHandler(file_handler)
+        
         # Prevent propagation to root logger to avoid duplicate messages
         root_logger.propagate = False
         _CONFIGURED = True


### PR DESCRIPTION
Fixes #227

## Changes
- Add `log_file` parameter to `setup_logging()`
- Create `FileHandler` when `log_file` is specified
- Both stream and file handlers use the same formatter
- Maintains backward compatibility (`log_file` is optional)

## Usage
```python
from landmarkdiff.log import setup_logging

# Log to both console and file
setup_logging(level="INFO", log_file="app.log")
```