### PR TITLE
Update README with 3D reconstruction vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 [![Hugging Face Space](https://img.shields.io/badge/%F0%9F%A4%97-Live%20Demo-yellow)](https://huggingface.co/spaces/dreamlessx/LandmarkDiff)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 
-Photorealistic facial surgery outcome prediction from standard clinical photography, powered by anatomically-conditioned latent diffusion.
+Photorealistic facial surgery outcome prediction -- from a single 2D photo today, to full 3D reconstruction from a phone video scan tomorrow. Powered by anatomically-conditioned latent diffusion.
 
 <table>
 <tr>
 <td width="50%">
 
-**Input:** Single 2D photo (phone camera or clinical)
-**Output:** Photorealistic post-op prediction
-**No** 3D scans, depth sensors, or multi-view rigs
+**Input:** Single 2D photo today -- phone video scan for 3D coming next
+**Output:** Photorealistic post-op prediction (2D now, interactive 3D on the roadmap)
+**Just a phone** -- no depth sensors, no clinical equipment
 
 </td>
 <td width="50%">
@@ -28,6 +28,14 @@ Photorealistic facial surgery outcome prediction from standard clinical photogra
 </td>
 </tr>
 </table>
+
+### Where We're Headed
+
+The current 2D pipeline is the foundation. The end goal is something closer to this: you hold up your phone, slowly rotate your head (like Apple's personalized spatial audio scan), and we reconstruct a full 3D model of your face from that video alone. Surgical deformations then happen in 3D space -- anatomically grounded, not pixel-level warping -- and you get an interactive model you can rotate to see the predicted result from any angle.
+
+No depth sensors, no clinical scanning rigs, no special hardware. Just a phone camera, a short video, and a 3D reconstruction backbone (think FLAME morphable model fitting or 3DGS-style approaches). The patient sees exactly what they're signing up for, from every viewing angle, before committing to surgery.
+
+We're building toward this in stages. The 2D single-photo pipeline ships now and works well. 3D reconstruction and volumetric deformation are next.
 
 LandmarkDiff extracts MediaPipe's 478-point face mesh from the input photo, applies procedure-specific Gaussian RBF deformations calibrated from anthropometric surgical data, renders the deformed mesh as a tessellation wireframe, and feeds that wireframe into a ControlNet-conditioned Stable Diffusion 1.5 backbone to synthesize the predicted face. The output is composited back onto the original image using Laplacian pyramid blending with feathered surgical masks, then refined through neural face restoration and identity verification.
 
@@ -49,6 +57,7 @@ python scripts/run_inference.py photo.jpg --procedure rhinoplasty --intensity 60
 
 ## Table of Contents
 
+- [Where We're Headed](#where-were-headed)
 - [Features](#features)
 - [Why LandmarkDiff](#why-landmarkdiff)
 - [Supported Procedures](#supported-procedures)
@@ -887,10 +896,13 @@ make clean           # remove build artifacts
 - [ ] arXiv preprint
 
 ### Future (v1.0)
-- [ ] FLAME 3D morphable model integration for depth-aware deformation
+- [ ] Phone video capture -- rotate head, reconstruct full 3D face from frames
+- [ ] FLAME 3D morphable model fitting from monocular video
+- [ ] 3D surgical deformation -- procedure-specific warps in volumetric space
+- [ ] Interactive 3D preview -- rotate the predicted result from any angle
 - [ ] Multi-view consistency loss across frontal/profile predictions
 - [ ] Physics-informed tissue simulation (FEM for soft tissue response)
-- [ ] React Native mobile capture app with standardized clinical photo acquisition
+- [ ] Mobile capture app with guided head-rotation scan
 - [ ] Cloud deployment with Triton inference server
 
 ### Publication Targets


### PR DESCRIPTION
## Summary
- Reframe project tagline: single 2D photo is the foundation, phone video -> 3D model is the goal
- Update feature table to signal phone-scan and interactive 3D on the roadmap
- Add "Where We're Headed" section describing the full phone-video -> 3D reconstruction -> any-angle preview pipeline
- Expand v1.0 roadmap with concrete 3D milestones (FLAME fitting, volumetric deformation, mobile scan app)
- All existing 2D capability documentation preserved intact

## Test plan
- [ ] README renders correctly on GitHub
- [ ] No broken links or formatting issues
- [ ] Table of contents anchor link works for new section
- [ ] Existing content preserved