### PR TITLE
Add 3D reconstruction contribution areas to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ If you have questions that this guide doesn't answer, feel free to open a [Discu
 - [Submitting Changes](#submitting-changes)
 - [Adding a New Procedure Preset](#adding-a-new-procedure-preset)
 - [Adding Clinical Flags](#adding-clinical-flags)
+- [3D Reconstruction Contributions](#3d-reconstruction-contributions)
 - [Documentation](#documentation)
 - [Issue Labels](#issue-labels)
 - [Recognition](#recognition)
@@ -329,6 +330,51 @@ To add a new clinical flag:
 4. **Add the flag to the Gradio demo** in `scripts/app.py` -- typically as a checkbox in Tab 1.
 5. **Write tests** that verify the flag actually modifies the output relative to the unflagged case.
 6. **Document** the clinical rationale. Include references to the medical literature if possible.
+
+---
+
+## 3D Reconstruction Contributions
+
+LandmarkDiff is moving toward a 3D-native pipeline: a patient captures a short video scan of their face with a phone (rotating their head, similar to Apple's personalized spatial audio head scanning), and the system reconstructs a 3D face model, applies surgical deformations in 3D space, and renders a realistic preview from any angle. This is future work, but contributors can start exploring these areas now.
+
+### 3D face reconstruction
+
+The current pipeline operates on single 2D images. Lifting to 3D requires fitting a parametric face model or learning an implicit representation from a video sequence.
+
+Areas where contributions are welcome:
+
+- **FLAME integration** -- fitting [FLAME](https://flame.is.tue.mpg.de/) parameters from MediaPipe landmarks or dense face alignment, producing a textured 3D mesh from a single frame or short video.
+- **Neural implicit representations** -- NeRF or 3D Gaussian Splatting (3DGS) approaches for head reconstruction from a phone video scan. Particularly useful: methods that work with sparse views (10-30 frames) and reconstruct in under a minute.
+- **Mesh-landmark correspondence** -- mapping the 478 MediaPipe landmarks to FLAME mesh vertices so that existing 2D procedure presets can be projected into 3D displacement vectors.
+
+If you have experience with DECA, EMOCA, PanoHead, or similar, your expertise is directly applicable.
+
+### 3D viewer and rendering
+
+Once a deformed 3D model exists, patients need to view it interactively.
+
+- **WebGL/three.js viewer** -- a browser-based viewer that renders the reconstructed face from arbitrary viewpoints, with controls for rotating, zooming, and comparing pre/post deformation side by side.
+- **Gradio 3D integration** -- extending the existing Gradio demo (`scripts/app.py`) to embed a 3D model viewer tab alongside the current 2D outputs.
+- **Texture and lighting** -- realistic relighting and texture transfer so the 3D preview looks natural rather than synthetic.
+
+### Mobile capture pipeline
+
+The phone-scan capture workflow is a critical UX piece.
+
+- **Frame selection** -- given a video of a patient rotating their head, select the N most informative frames (coverage, sharpness, landmark confidence) for reconstruction.
+- **Real-time guidance** -- lightweight on-device feedback telling the patient to turn left, tilt up, etc., ensuring sufficient angular coverage.
+- **Landmark tracking across frames** -- temporally consistent MediaPipe tracking with outlier rejection and smoothing.
+
+### 3D evaluation metrics
+
+We will need metrics that go beyond 2D FID and LPIPS:
+
+- **3D landmark error** -- Euclidean distance between predicted and ground-truth 3D landmark positions.
+- **Mesh surface distance** -- Chamfer distance or Hausdorff distance between reconstructed and reference meshes.
+- **Multi-view consistency** -- measuring whether the deformed model renders consistently across viewpoints (no view-dependent artifacts).
+- **Identity preservation in 3D** -- extending the current ArcFace identity score to aggregate across multiple rendered views.
+
+If any of these areas interest you, open an issue tagged `enhancement` describing what you want to work on, and we can discuss the approach before you start coding.
 
 ---
 

--- a/MODEL_ZOO.md
+++ b/MODEL_ZOO.md
@@ -56,3 +56,30 @@ python scripts/train_controlnet.py --data_dir data/synthetic_pairs/ --output_dir
 | Training Phase A (10K steps) | 24 GB | 40 GB (A100) | ~1 hour |
 | Training Phase A (50K steps) | 40 GB | 80 GB (A100) | ~6 hours |
 | Training Phase B | 40 GB | 80 GB (A100) | ~30 hours |
+
+## Planned Models
+
+The following models are on the roadmap as LandmarkDiff moves toward a 3D-native pipeline (phone video scan to interactive 3D surgical preview). None of these are available yet -- this section previews what is coming.
+
+| Model | Approach | Purpose | Status |
+|-------|----------|---------|--------|
+| 3D Face Reconstruction | FLAME-based fitting or neural implicit (NeRF/3DGS) | Reconstruct a textured 3D face mesh from a short phone video scan | Research |
+| 3D Deformation Model | Mesh-space surgical simulation | Apply procedure-specific displacements directly on 3D mesh vertices instead of 2D pixel warps | Research |
+| Multi-View Consistency | View-conditioned diffusion or 3DGS rendering | Ensure deformed face renders consistently across arbitrary viewpoints | Research |
+| Mobile-Optimized Inference | Distilled/quantized pipeline | Run landmark detection, reconstruction, and preview on-device with acceptable latency | Planned |
+
+### 3D face reconstruction model
+
+Replaces the current single-image 2D pipeline entry point. Given 10-30 frames from a phone video scan (patient rotating their head), reconstructs a FLAME mesh with per-vertex texture. Candidate approaches include DECA-style regression, optimization-based FLAME fitting from MediaPipe landmarks, and feed-forward 3DGS methods.
+
+### 3D deformation model
+
+Operates on the reconstructed mesh rather than on 2D pixel coordinates. Existing procedure presets (rhinoplasty, blepharoplasty, etc.) would be re-expressed as 3D vertex displacement fields, enabling anatomically grounded deformations that look correct from any viewing angle.
+
+### Multi-view consistency model
+
+Ensures that the deformed 3D representation renders without view-dependent artifacts. This may be handled implicitly by the 3D representation (mesh or 3DGS) or may require an additional consistency loss during training.
+
+### Mobile-optimized inference model
+
+A distilled or quantized version of the pipeline targeting on-device inference. The goal is real-time landmark tracking and capture guidance, with reconstruction offloaded to a server or run locally on modern phones.


### PR DESCRIPTION
## Summary
- Add 3D reconstruction contribution section to CONTRIBUTING.md covering FLAME integration, NeRF/3DGS, 3D viewer/rendering, mobile capture pipeline, and 3D evaluation metrics
- Add planned 3D models section to MODEL_ZOO.md with roadmap for reconstruction, deformation, multi-view consistency, and mobile-optimized models
- Reflects the expanded project vision: phone video scan -> 3D face reconstruction -> surgical deformation in 3D -> interactive preview from any angle

## Test plan
- [ ] CONTRIBUTING.md renders correctly on GitHub
- [ ] MODEL_ZOO.md renders correctly on GitHub
- [ ] No broken links
- [ ] Table of Contents entry links to new section