### PR TITLE
Fix HF Space short_description length

### DIFF
--- a/scripts/hf_space/README.md
+++ b/scripts/hf_space/README.md
@@ -9,7 +9,7 @@ python_version: "3.11"
 app_file: app.py
 pinned: true
 license: mit
-short_description: Facial surgery outcome prediction -- 2D foundation toward 3D reconstruction
+short_description: Facial surgery prediction -- 2D foundation toward 3D
 tags:
   - medical-imaging
   - face


### PR DESCRIPTION
## Summary
- Shorten short_description to 52 chars (HF enforces 60-char max)
- Previous version was 80+ chars and failed HF upload validation

## Test plan
- [ ] README.md uploads to HF Space without error