### PR TITLE
Fix PyPI publish: decouple from test-pypi failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
   test-pypi:
     needs: build
     runs-on: ubuntu-latest
+    continue-on-error: true
     environment:
       name: test-pypi
       url: https://test.pypi.org/p/landmarkdiff
@@ -52,7 +53,8 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   pypi:
-    needs: test-pypi
+    needs: build
+    if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
## Summary
- Make test-pypi step `continue-on-error: true`
- Change pypi job to depend on build (not test-pypi)
- Prevents test-pypi trusted publisher issues from blocking real PyPI publish

## Root cause
Trusted publishing wasn't configured on Test PyPI, causing test-pypi to fail, which blocked the pypi job entirely.

## Test plan
- [ ] Re-run publish workflow after setting up trusted publisher on PyPI