### PR TITLE
Redesign logo with golden decagon matrix

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
   <defs>
-    <radialGradient id="bg" cx="50%" cy="42%" r="62%">
+    <radialGradient id="bg" cx="50%" cy="45%" r="60%">
       <stop offset="0%" stop-color="#1e293b"/>
       <stop offset="100%" stop-color="#0f172a"/>
     </radialGradient>
@@ -8,128 +8,154 @@
       <feGaussianBlur in="SourceGraphic" stdDeviation="1.5" result="blur"/>
       <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
-    <filter id="soft">
-      <feGaussianBlur in="SourceGraphic" stdDeviation="0.5" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
   </defs>
 
-  <!-- Background -->
+  <!-- Background circle -->
   <circle cx="64" cy="64" r="60" fill="url(#bg)" stroke="#1e40af" stroke-width="1.2"/>
-  <circle cx="64" cy="64" r="58.5" fill="none" stroke="#3b82f6" stroke-width="0.3" opacity="0.2"/>
+  <circle cx="64" cy="64" r="58.5" fill="none" stroke="#3b82f6" stroke-width="0.3" opacity="0.15"/>
 
-  <!-- Golden ratio face outline - clean proportional wireframe -->
-  <g stroke="#3b82f6" stroke-width="0.6" fill="none" opacity="0.5" filter="url(#soft)">
-    <!-- Face oval outline -->
-    <path d="M 64,16 C 44,16 32,28 30,44 C 28,58 30,70 36,80 C 42,90 52,98 64,100 C 76,98 86,90 92,80 C 98,70 100,58 98,44 C 96,28 84,16 64,16 Z"/>
-
-    <!-- Horizontal proportion lines -->
-    <line x1="34" y1="38" x2="94" y2="38" opacity="0.3"/>
-    <line x1="36" y1="50" x2="92" y2="50" opacity="0.3"/>
-    <line x1="38" y1="62" x2="90" y2="62" opacity="0.3"/>
-    <line x1="40" y1="74" x2="88" y2="74" opacity="0.3"/>
-    <line x1="48" y1="86" x2="80" y2="86" opacity="0.3"/>
-
-    <!-- Vertical center line -->
-    <line x1="64" y1="16" x2="64" y2="100" opacity="0.25"/>
+  <!-- PRIMARY GOLDEN DECAGON MATRIX - the face framework -->
+  <!-- Main decagon (10-sided, phi-based) centered on face -->
+  <g stroke="#3b82f6" stroke-width="0.5" fill="none" opacity="0.25">
+    <polygon points="64,14 82,20 93,36 93,56 82,72 64,78 46,72 35,56 35,36 46,20"/>
   </g>
 
-  <!-- Triangulated mesh overlay -->
-  <g stroke="#3b82f6" stroke-width="0.65" fill="none" opacity="0.55">
-    <!-- Forehead triangles -->
-    <polygon points="64,20 50,26 58,34"/>
-    <polygon points="64,20 78,26 70,34"/>
-    <polygon points="58,34 64,30 70,34"/>
-    <polygon points="50,26 42,34 58,34"/>
-    <polygon points="78,26 86,34 70,34"/>
+  <!-- Secondary decagon (inverted, smaller by phi) -->
+  <g stroke="#3b82f6" stroke-width="0.4" fill="none" opacity="0.18">
+    <polygon points="64,22 77,26 85,38 85,54 77,66 64,70 51,66 43,54 43,38 51,26"/>
+  </g>
 
-    <!-- Brow/temple -->
-    <polygon points="42,34 38,44 50,40"/>
-    <polygon points="86,34 90,44 78,40"/>
-    <polygon points="50,40 58,34 58,42"/>
-    <polygon points="78,40 70,34 70,42"/>
+  <!-- Phi-ratio horizontal guide lines -->
+  <g stroke="#3b82f6" stroke-width="0.35" fill="none" opacity="0.2">
+    <!-- Hairline -->
+    <line x1="38" y1="22" x2="90" y2="22"/>
+    <!-- Brow line (1/phi of face) -->
+    <line x1="35" y1="34" x2="93" y2="34"/>
+    <!-- Eye line -->
+    <line x1="36" y1="42" x2="92" y2="42"/>
+    <!-- Nose base -->
+    <line x1="40" y1="58" x2="88" y2="58"/>
+    <!-- Lip line -->
+    <line x1="42" y1="66" x2="86" y2="66"/>
+    <!-- Chin -->
+    <line x1="48" y1="78" x2="80" y2="78"/>
+    <!-- Vertical midline -->
+    <line x1="64" y1="14" x2="64" y2="92"/>
+  </g>
 
-    <!-- Eye region -->
-    <polygon points="38,44 50,40 46,50"/>
-    <polygon points="50,40 58,42 54,50"/>
-    <polygon points="46,50 54,50 50,46"/>
-    <polygon points="90,44 78,40 82,50"/>
-    <polygon points="78,40 70,42 74,50"/>
-    <polygon points="82,50 74,50 78,46"/>
+  <!-- FACE OUTLINE - smooth oval derived from decagon vertices -->
+  <g stroke="#3b82f6" stroke-width="0.7" fill="none" opacity="0.4">
+    <path d="M 64,16 C 47,16 36,26 34,40 C 32,52 34,64 40,76 C 46,86 54,92 64,94 C 74,92 82,86 88,76 C 94,64 96,52 94,40 C 92,26 81,16 64,16 Z"/>
+  </g>
 
-    <!-- Nose bridge -->
-    <polygon points="58,42 64,40 70,42"/>
-    <polygon points="58,42 64,52 54,50"/>
-    <polygon points="70,42 64,52 74,50"/>
+  <!-- SECONDARY DECAGON MATRICES - facial features -->
+  <!-- Left eye decagon -->
+  <g stroke="#60a5fa" stroke-width="0.5" fill="none" opacity="0.4">
+    <polygon points="50,38 54,36 58,38 58,42 56,45 52,45 48,44 46,42 46,39 48,37"/>
+  </g>
+  <!-- Right eye decagon -->
+  <g stroke="#60a5fa" stroke-width="0.5" fill="none" opacity="0.4">
+    <polygon points="70,38 74,36 78,38 80,42 80,44 78,45 74,45 70,44 68,42 68,39"/>
+  </g>
 
-    <!-- Nose tip -->
-    <polygon points="64,52 58,58 62,62"/>
-    <polygon points="64,52 70,58 66,62"/>
-    <polygon points="62,62 64,64 66,62"/>
+  <!-- Nose pentagon -->
+  <g stroke="#60a5fa" stroke-width="0.5" fill="none" opacity="0.35">
+    <polygon points="64,40 69,50 67,58 61,58 59,50"/>
+  </g>
 
-    <!-- Cheek -->
-    <polygon points="38,44 46,50 40,60"/>
-    <polygon points="90,44 82,50 88,60"/>
-    <polygon points="46,50 54,50 50,60"/>
-    <polygon points="82,50 74,50 78,60"/>
+  <!-- Mouth decagon (smaller) -->
+  <g stroke="#60a5fa" stroke-width="0.45" fill="none" opacity="0.35">
+    <polygon points="56,62 58,60 62,59 66,59 70,60 72,62 70,65 66,67 62,67 58,65"/>
+  </g>
 
-    <!-- Mouth -->
-    <polygon points="50,60 58,58 54,68"/>
-    <polygon points="78,60 70,58 74,68"/>
-    <polygon points="58,58 62,62 58,68"/>
-    <polygon points="70,58 66,62 70,68"/>
-    <polygon points="62,62 64,64 64,68"/>
-    <polygon points="66,62 64,64 64,68"/>
+  <!-- Chin pentagon -->
+  <g stroke="#60a5fa" stroke-width="0.4" fill="none" opacity="0.3">
+    <polygon points="64,70 72,74 70,82 58,82 56,74"/>
+  </g>
 
-    <!-- Jaw -->
-    <polygon points="40,60 50,60 44,72"/>
-    <polygon points="88,60 78,60 84,72"/>
-    <polygon points="44,72 54,68 50,78"/>
-    <polygon points="84,72 74,68 78,78"/>
+  <!-- TRIANGULATED MESH - connecting the decagon vertices -->
+  <g stroke="#3b82f6" stroke-width="0.45" fill="none" opacity="0.35">
+    <!-- Forehead triangulation -->
+    <line x1="46" y1="20" x2="64" y2="16"/>
+    <line x1="64" y1="16" x2="82" y2="20"/>
+    <line x1="46" y1="20" x2="54" y2="36"/>
+    <line x1="82" y1="20" x2="74" y2="36"/>
+    <line x1="64" y1="16" x2="64" y2="34"/>
+    <line x1="46" y1="20" x2="64" y2="34"/>
+    <line x1="82" y1="20" x2="64" y2="34"/>
+
+    <!-- Temple to eye -->
+    <line x1="35" y1="36" x2="46" y2="38"/>
+    <line x1="93" y1="36" x2="80" y2="38"/>
+
+    <!-- Eye to nose bridge -->
+    <line x1="58" y1="42" x2="64" y2="40"/>
+    <line x1="68" y1="42" x2="64" y2="40"/>
+
+    <!-- Cheek lines -->
+    <line x1="35" y1="56" x2="48" y2="44"/>
+    <line x1="93" y1="56" x2="80" y2="44"/>
+    <line x1="35" y1="56" x2="56" y2="58"/>
+    <line x1="93" y1="56" x2="72" y2="58"/>
+
+    <!-- Nose to mouth -->
+    <line x1="61" y1="58" x2="58" y2="60"/>
+    <line x1="67" y1="58" x2="70" y2="60"/>
+
+    <!-- Jaw lines -->
+    <line x1="46" y1="72" x2="56" y2="62"/>
+    <line x1="82" y1="72" x2="72" y2="62"/>
+    <line x1="46" y1="72" x2="56" y2="74"/>
+    <line x1="82" y1="72" x2="72" y2="74"/>
 
     <!-- Chin -->
-    <polygon points="54,68 58,68 56,74"/>
-    <polygon points="74,68 70,68 72,74"/>
-    <polygon points="56,74 64,68 64,80"/>
-    <polygon points="72,74 64,68 64,80"/>
-    <polygon points="50,78 56,74 64,80"/>
-    <polygon points="78,78 72,74 64,80"/>
+    <line x1="64" y1="78" x2="58" y2="67"/>
+    <line x1="64" y1="78" x2="70" y2="67"/>
   </g>
 
-  <!-- Key nodes - left side (blue, original) -->
-  <g fill="#60a5fa" opacity="0.65">
-    <circle cx="50" cy="26" r="1.5"/>
-    <circle cx="42" cy="34" r="1.5"/>
-    <circle cx="50" cy="40" r="1.5"/>
-    <circle cx="46" cy="50" r="1.5"/>
-    <circle cx="58" cy="58" r="1.5"/>
-    <circle cx="54" cy="68" r="1.5"/>
-    <circle cx="50" cy="78" r="1.5"/>
-    <circle cx="64" cy="20" r="1.5"/>
-    <circle cx="64" cy="52" r="1.5"/>
-    <circle cx="64" cy="80" r="1.5"/>
+  <!-- KEY LANDMARK NODES - left side (blue, symmetric) -->
+  <g fill="#60a5fa" opacity="0.6">
+    <circle cx="46" cy="20" r="1.3"/>
+    <circle cx="35" cy="36" r="1.3"/>
+    <circle cx="46" cy="38" r="1.3"/>
+    <circle cx="48" cy="44" r="1.3"/>
+    <circle cx="35" cy="56" r="1.3"/>
+    <circle cx="52" cy="45" r="1.3"/>
+    <circle cx="59" cy="50" r="1.3"/>
+    <circle cx="56" cy="62" r="1.3"/>
+    <circle cx="46" cy="72" r="1.3"/>
+    <circle cx="56" cy="74" r="1.3"/>
+    <circle cx="64" cy="16" r="1.3"/>
+    <circle cx="64" cy="40" r="1.3"/>
+    <circle cx="64" cy="78" r="1.5"/>
+    <circle cx="64" cy="94" r="1.3"/>
   </g>
 
-  <!-- Right side nodes - amber (deformed) with glow -->
+  <!-- RIGHT SIDE NODES - amber (deformed) with glow -->
+  <!-- This is the "Diff" -- the right side is displaced -->
   <g fill="#f59e0b" filter="url(#glow)">
-    <circle cx="80" cy="26" r="1.8"/>
-    <circle cx="90" cy="44" r="1.8"/>
-    <circle cx="82" cy="50" r="1.8"/>
-    <circle cx="70" cy="58" r="1.8"/>
-    <circle cx="74" cy="68" r="1.8"/>
-    <circle cx="78" cy="78" r="1.8"/>
+    <circle cx="82" cy="20" r="1.6"/>
+    <circle cx="93" cy="36" r="1.6"/>
+    <circle cx="80" cy="38" r="1.6"/>
+    <circle cx="80" cy="44" r="1.6"/>
+    <circle cx="93" cy="56" r="1.6"/>
+    <circle cx="74" cy="45" r="1.6"/>
+    <circle cx="69" cy="50" r="1.6"/>
+    <circle cx="72" cy="62" r="1.6"/>
+    <circle cx="82" cy="72" r="1.6"/>
+    <circle cx="72" cy="74" r="1.6"/>
   </g>
 
-  <!-- Deformation displacement arrows (subtle) -->
-  <g stroke="#f59e0b" stroke-width="1" fill="none" opacity="0.5" stroke-linecap="round">
-    <line x1="66" y1="62" x2="68" y2="59"/>
-    <line x1="70" y1="58" x2="72" y2="55"/>
-    <line x1="64" y1="52" x2="65" y2="49"/>
+  <!-- Deformation vectors on nose (the procedure being shown) -->
+  <g stroke="#f59e0b" stroke-width="0.9" fill="none" opacity="0.5" stroke-linecap="round">
+    <line x1="69" y1="50" x2="71" y2="47"/>
+    <line x1="67" y1="58" x2="69" y2="55"/>
+    <line x1="64" y1="40" x2="64" y2="37"/>
   </g>
 
-  <!-- Glow behind displacement area -->
-  <g fill="#f59e0b" opacity="0.15">
-    <circle cx="69" cy="56" r="8"/>
-    <circle cx="66" cy="60" r="5"/>
+  <!-- Subtle amber glow behind deformation zone -->
+  <g fill="#f59e0b" opacity="0.12">
+    <circle cx="68" cy="50" r="10"/>
+    <circle cx="67" cy="57" r="6"/>
   </g>
 </svg>


### PR DESCRIPTION
Redesign logo SVG inspired by the Marquardt beauty mask golden ratio face anatomy. Uses primary/secondary golden decagons, phi-ratio proportion guides, and feature-specific decagon matrices for eyes, nose, mouth, and chin. Right-side amber nodes show deformation.