### PR TITLE
Sync docs version to 0.2.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 project = "LandmarkDiff"
 author = "dreamlessx"
 copyright = "2024-2026, dreamlessx"
-release = "0.2.0"
+release = "0.2.2"
 
 extensions = [
     "sphinx.ext.autodoc",


### PR DESCRIPTION
## Summary
- Update `docs/conf.py` release version from 0.2.0 to 0.2.2
- Matches CITATION.cff, pyproject.toml, and __init__.py