### PR TITLE
Fix ruff format violation breaking CI

### DIFF
--- a/scripts/train_controlnet.py
+++ b/scripts/train_controlnet.py
@@ -1001,7 +1001,9 @@ def train(
                         metrics=_ckpt_metrics,
                         phase=phase,
                     )
-                    logger.info("Checkpoint saved: %s | %s", ckpt_dir, train._ckpt_manager.summary())
+                    logger.info(
+                        "Checkpoint saved: %s | %s", ckpt_dir, train._ckpt_manager.summary()
+                    )
                 except ImportError:
                     # Fallback: save without manager
                     ckpt_dir = out / f"checkpoint-{global_step}"


### PR DESCRIPTION
## Summary
- Fix line-too-long formatting violation in `scripts/train_controlnet.py` (line 1004)
- The `logger.info()` call added in PR #265 exceeded ruff's line length limit, causing the CI format check to fail
- Test and type-check jobs were blocked since they depend on the lint job

## Test plan
- [x] `ruff format --check` passes locally
- [x] `ruff check` passes locally
- CI should go green after merge