### PR TITLE
Polish repo metadata, fix CI, and enable GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![CI](https://github.com/dreamlessx/LandmarkDiff-public/actions/workflows/ci.yml/badge.svg)](https://github.com/dreamlessx/LandmarkDiff-public/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/dreamlessx/LandmarkDiff-public/graph/badge.svg)](https://codecov.io/gh/dreamlessx/LandmarkDiff-public)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://dreamlessx.github.io/LandmarkDiff-public/)
 [![PyPI version](https://img.shields.io/pypi/v/landmarkdiff.svg)](https://pypi.org/project/landmarkdiff/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10 | 3.11 | 3.12](https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12-blue.svg)](https://www.python.org/downloads/)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ It works by extracting MediaPipe's 478-point face mesh from the input photo, app
 
 - [Quickstart notebook](../examples/quickstart.ipynb) -- load the pipeline, run predictions, compare procedures
 - [CHANGELOG](../CHANGELOG.md) -- what changed between releases
-- [Wiki](https://github.com/dreamlessx/LandmarkDiff-public/wiki) -- extended guides, FAQ, architecture notes
+- [Discussions](https://github.com/dreamlessx/LandmarkDiff-public/discussions) -- questions, ideas, and community discussion
 - [API reference](api/) -- per-module documentation
 
 ---

--- a/docs/model_zoo.md
+++ b/docs/model_zoo.md
@@ -1,0 +1,1 @@
+../MODEL_ZOO.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: LandmarkDiff
+site_description: Photorealistic facial surgery outcome prediction from a single photo, powered by anatomically-conditioned latent diffusion.
 site_url: https://dreamlessx.github.io/LandmarkDiff-public
 repo_url: https://github.com/dreamlessx/LandmarkDiff-public
 repo_name: dreamlessx/LandmarkDiff-public
@@ -70,4 +71,7 @@ plugins:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/dreamlessx
+      link: https://github.com/dreamlessx/LandmarkDiff-public
+    - icon: fontawesome/solid/rocket
+      link: https://huggingface.co/spaces/dreamlessx/LandmarkDiff
+      name: Live Demo on Hugging Face

--- a/scripts/train_controlnet.py
+++ b/scripts/train_controlnet.py
@@ -1001,7 +1001,9 @@ def train(
                         metrics=_ckpt_metrics,
                         phase=phase,
                     )
-                    logger.info("Checkpoint saved: %s | %s", ckpt_dir, train._ckpt_manager.summary())
+                    logger.info(
+                        "Checkpoint saved: %s | %s", ckpt_dir, train._ckpt_manager.summary()
+                    )
                 except ImportError:
                     # Fallback: save without manager
                     ckpt_dir = out / f"checkpoint-{global_step}"


### PR DESCRIPTION
## Summary

- Fix ruff format violation in `scripts/train_controlnet.py` that broke the CI badge on main (line 1004 exceeded line length)
- Add Docs badge to README linking to the newly enabled GitHub Pages site
- Enable GitHub Pages deployment from the existing `gh-pages` branch
- Add `site_description` to `mkdocs.yml` for search engine discoverability
- Fix broken mkdocs nav entries: `contributing.md` and `model_zoo.md` now symlink to root-level files
- Replace dead Wiki link in `docs/index.md` with active Discussions link
- Point mkdocs social link to the repo URL (was personal profile) and add HF Space link
- Disable unused Wiki feature to reduce clutter

## Test plan

- [ ] CI lint/format/test jobs pass (the format fix is the main fix here)
- [ ] Docs badge renders correctly in README
- [ ] GitHub Pages site loads at https://dreamlessx.github.io/LandmarkDiff-public/
- [ ] mkdocs Contributing and Model Zoo pages resolve via symlinks