### PR TITLE
Fix E501 lint errors from procedure list expansion

### DIFF
--- a/landmarkdiff/data_version.py
+++ b/landmarkdiff/data_version.py
@@ -48,13 +48,13 @@ class FileEntry:
         # Infer procedure from filename
         proc = ""
         for p in [
-                "rhinoplasty",
-                "blepharoplasty",
-                "rhytidectomy",
-                "orthognathic",
-                "brow_lift",
-                "mentoplasty",
-            ]:
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             if p in filepath.name or p in str(filepath.parent):
                 proc = p
                 break

--- a/scripts/analyze_training_data.py
+++ b/scripts/analyze_training_data.py
@@ -121,7 +121,14 @@ def analyze_dataset(
             wave = pairs_meta[prefix].get("wave", "unknown")
         else:
             proc = "unknown"
-            for p in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+            for p in [
+                "rhinoplasty",
+                "blepharoplasty",
+                "rhytidectomy",
+                "orthognathic",
+                "brow_lift",
+                "mentoplasty",
+            ]:
                 if p in prefix:
                     proc = p
                     break

--- a/scripts/app.py
+++ b/scripts/app.py
@@ -199,11 +199,13 @@ def create_comparison(
     blepharoplasty: float,
     rhytidectomy: float,
     orthognathic: float,
+    brow_lift: float,
+    mentoplasty: float,
 ) -> tuple:
     """Multi-procedure comparison."""
     if image_rgb is None:
         blank = np.zeros((512, 512, 3), dtype=np.uint8)
-        return blank, blank, blank, blank
+        return blank, blank, blank, blank, blank, blank
 
     image_bgr = image_rgb[:, :, ::-1].copy()
     image_bgr = cv2.resize(image_bgr, (512, 512))
@@ -211,7 +213,7 @@ def create_comparison(
     face = extract_landmarks(image_bgr)
     if face is None:
         rgb = bgr_to_rgb(image_bgr)
-        return rgb, rgb, rgb, rgb
+        return rgb, rgb, rgb, rgb, rgb, rgb
 
     results = []
     for proc, inten in [
@@ -219,6 +221,8 @@ def create_comparison(
         ("blepharoplasty", blepharoplasty),
         ("rhytidectomy", rhytidectomy),
         ("orthognathic", orthognathic),
+        ("brow_lift", brow_lift),
+        ("mentoplasty", mentoplasty),
     ]:
         if inten < 1.0:
             results.append(bgr_to_rgb(image_bgr))
@@ -363,6 +367,8 @@ def build_app():
                     slider_bleph = gr.Slider(0, 100, 0, step=1, label="Blepharoplasty")
                     slider_rhyti = gr.Slider(0, 100, 0, step=1, label="Rhytidectomy")
                     slider_ortho = gr.Slider(0, 100, 0, step=1, label="Orthognathic")
+                    slider_brow = gr.Slider(0, 100, 0, step=1, label="Brow Lift")
+                    slider_mento = gr.Slider(0, 100, 0, step=1, label="Mentoplasty")
                     compare_btn = gr.Button("Compare All", variant="primary", size="lg")
                 with gr.Column(scale=2):
                     with gr.Row():
@@ -371,6 +377,9 @@ def build_app():
                     with gr.Row():
                         out_rhyti = gr.Image(label="Rhytidectomy", height=256)
                         out_ortho = gr.Image(label="Orthognathic", height=256)
+                    with gr.Row():
+                        out_brow = gr.Image(label="Brow Lift", height=256)
+                        out_mento = gr.Image(label="Mentoplasty", height=256)
 
             multi_inputs = [
                 input_image_multi,
@@ -378,10 +387,19 @@ def build_app():
                 slider_bleph,
                 slider_rhyti,
                 slider_ortho,
+                slider_brow,
+                slider_mento,
             ]
-            multi_outputs = [out_rhino, out_bleph, out_rhyti, out_ortho]
+            multi_outputs = [out_rhino, out_bleph, out_rhyti, out_ortho, out_brow, out_mento]
             compare_btn.click(fn=create_comparison, inputs=multi_inputs, outputs=multi_outputs)
-            for slider in [slider_rhino, slider_bleph, slider_rhyti, slider_ortho]:
+            for slider in [
+                slider_rhino,
+                slider_bleph,
+                slider_rhyti,
+                slider_ortho,
+                slider_brow,
+                slider_mento,
+            ]:
                 slider.change(fn=create_comparison, inputs=multi_inputs, outputs=multi_outputs)
 
         # ---- Tab 3: Intensity Sweep ----

--- a/scripts/batch_inference.py
+++ b/scripts/batch_inference.py
@@ -64,7 +64,14 @@ from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
 logger = logging.getLogger(__name__)
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def process_image(

--- a/scripts/benchmark_quality.py
+++ b/scripts/benchmark_quality.py
@@ -48,7 +48,14 @@ from landmarkdiff.manipulation import apply_procedure_preset
 from landmarkdiff.masking import generate_surgical_mask
 from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 FITZ_TYPES = ["I", "II", "III", "IV", "V", "VI"]
 
 

--- a/scripts/build_training_dataset.py
+++ b/scripts/build_training_dataset.py
@@ -136,7 +136,14 @@ def _copy_v3_pairs(v3_dir: Path, output_dir: Path, start_idx: int) -> tuple[int,
 
         # Infer procedure from prefix (e.g. "rhinoplasty_000042")
         proc = "unknown"
-        for p in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for p in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             if prefix.startswith(p):
                 proc = p
                 break
@@ -319,7 +326,14 @@ def build_dataset(
 
             # Infer procedure from real pair filename
             real_proc = "unknown"
-            for p in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+            for p in [
+                "rhinoplasty",
+                "blepharoplasty",
+                "rhytidectomy",
+                "orthognathic",
+                "brow_lift",
+                "mentoplasty",
+            ]:
                 if p in prefix.lower():
                     real_proc = p
                     break
@@ -460,7 +474,14 @@ def main():
     parser.add_argument(
         "--procedures",
         nargs="+",
-        default=["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"],
+        default=[
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     parser.add_argument("--no_augment", action="store_true", help="Skip augmenting real pairs")
     parser.add_argument(

--- a/scripts/clean_data.py
+++ b/scripts/clean_data.py
@@ -479,7 +479,14 @@ def main():
 
     if args.all_procedures:
         # Process each procedure subdirectory
-        procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        procedures = [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]
         all_stats = {}
 
         for proc in procedures:

--- a/scripts/clinical_demo.py
+++ b/scripts/clinical_demo.py
@@ -51,7 +51,14 @@ from landmarkdiff.manipulation import apply_procedure_preset
 from landmarkdiff.masking import generate_surgical_mask
 from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 PROCEDURE_DESCRIPTIONS = {
     "rhinoplasty": "Nose reshaping (rhinoplasty)",

--- a/scripts/compare_methods.py
+++ b/scripts/compare_methods.py
@@ -39,7 +39,14 @@ from landmarkdiff.manipulation import apply_procedure_preset
 from landmarkdiff.masking import generate_surgical_mask
 from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def process_tps(img: np.ndarray, procedure: str, intensity: float) -> np.ndarray | None:

--- a/scripts/compare_models.py
+++ b/scripts/compare_models.py
@@ -50,7 +50,14 @@ from landmarkdiff.manipulation import apply_procedure_preset
 from landmarkdiff.masking import generate_surgical_mask
 from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def load_test_samples(

--- a/scripts/compare_outputs.py
+++ b/scripts/compare_outputs.py
@@ -51,7 +51,14 @@ from landmarkdiff.manipulation import apply_procedure_preset
 from landmarkdiff.masking import generate_surgical_mask
 from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 PROC_LABELS = {
     "rhinoplasty": "Rhinoplasty",
     "blepharoplasty": "Blepharoplasty",

--- a/scripts/compute_baselines.py
+++ b/scripts/compute_baselines.py
@@ -235,7 +235,14 @@ def evaluate_baselines(
 
         # Infer procedure
         procedure = "unknown"
-        for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for proc in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             if proc in prefix:
                 procedure = proc
                 break

--- a/scripts/compute_fid.py
+++ b/scripts/compute_fid.py
@@ -38,7 +38,14 @@ import numpy as np
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def collect_target_images(data_dir: Path) -> list[Path]:

--- a/scripts/create_test_split.py
+++ b/scripts/create_test_split.py
@@ -37,7 +37,14 @@ import shutil
 from collections import defaultdict
 from pathlib import Path
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def extract_source_id(prefix: str, meta: dict) -> str:

--- a/scripts/cross_procedure_eval.py
+++ b/scripts/cross_procedure_eval.py
@@ -33,7 +33,14 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def load_pipeline(checkpoint: str, device: torch.device):

--- a/scripts/dataset_stats.py
+++ b/scripts/dataset_stats.py
@@ -30,7 +30,14 @@ import numpy as np
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def analyze_dataset(

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -183,7 +183,14 @@ def run_synthetic_demo(output_dir: str = "scripts/demo_output") -> None:
     cv2.imwrite(str(out / "03_synthetic_canny.png"), canny)
 
     # Apply each procedure
-    for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+    for proc in [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]:
         manip = apply_procedure_preset(face, proc, intensity=70.0, image_size=512)
         manip_img = render_landmark_image(manip, 512, 512)
         _, manip_canny, manip_wf = generate_conditioning(manip, 512, 512)
@@ -208,7 +215,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--procedure",
         default="rhinoplasty",
-        choices=["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"],
+        choices=[
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     parser.add_argument(
         "--intensity", type=float, default=50.0, help="Manipulation intensity 0-100"

--- a/scripts/ensemble_inference.py
+++ b/scripts/ensemble_inference.py
@@ -84,7 +84,14 @@ from landmarkdiff.postprocess import histogram_match_skin
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 # Diffusion prompt tuned for CrucibleAI ControlNet conditioned on MediaPipe mesh
 PROMPT = "high quality photo of a face after cosmetic surgery, realistic skin texture"

--- a/scripts/evaluate_checkpoint.py
+++ b/scripts/evaluate_checkpoint.py
@@ -55,7 +55,14 @@ def load_test_pairs(test_dir: Path) -> list[dict]:
 
         # Try to infer procedure from filename
         procedure = "unknown"
-        for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for proc in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             if proc in prefix:
                 procedure = proc
                 break

--- a/scripts/export_model.py
+++ b/scripts/export_model.py
@@ -70,7 +70,14 @@ def export_from_checkpoint(
         "total_parameters": total_params,
         "trainable_parameters": trainable_params,
         "format": "safetensors",
-        "procedures": ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"],
+        "procedures": [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
         "input_resolution": 512,
     }
     with open(out / "model_info.json", "w") as f:

--- a/scripts/export_results.py
+++ b/scripts/export_results.py
@@ -33,7 +33,14 @@ from pathlib import Path
 
 import numpy as np
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 FITZ_TYPES = ["I", "II", "III", "IV", "V", "VI"]
 
 

--- a/scripts/fast_split.py
+++ b/scripts/fast_split.py
@@ -26,7 +26,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = PROJECT_ROOT / "data" / "training_combined"
 SPLITS_DIR = PROJECT_ROOT / "data" / "splits"
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def fast_split(

--- a/scripts/gallery.py
+++ b/scripts/gallery.py
@@ -30,7 +30,14 @@ def add_label(img: np.ndarray, text: str, font_scale: float = 0.5) -> np.ndarray
 
 def make_procedure_comparison(face_dir: str, output_path: str) -> None:
     """Create a 6-procedure comparison grid from demo outputs."""
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     base = Path(face_dir)
     rows = []
 
@@ -247,7 +254,15 @@ if __name__ == "__main__":
     parser.add_argument(
         "--procedure",
         type=str,
-        choices=["all", "rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"],
+        choices=[
+            "all",
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
         default="all",
         help="Specific procedure to generate intensity sweep for (default: all)",
     )

--- a/scripts/generate_demos.py
+++ b/scripts/generate_demos.py
@@ -29,7 +29,14 @@ from landmarkdiff.masking import generate_surgical_mask
 from landmarkdiff.postprocess import full_postprocess
 from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 INTENSITIES = [40, 65, 90]
 
 

--- a/scripts/generate_figures.py
+++ b/scripts/generate_figures.py
@@ -262,7 +262,14 @@ def generate_conditioning_figure(
         print("Face detection failed, trying next image...")
         return
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     intensity = 65.0
 
     fig, axes = plt.subplots(4, 5, figsize=(LNCS_WIDTH_IN * 2, LNCS_WIDTH_IN * 1.6), dpi=300)
@@ -362,7 +369,14 @@ def generate_deformation_figure(
     if face is None:
         return
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     fig, axes = plt.subplots(1, 4, figsize=(LNCS_WIDTH_IN * 2, LNCS_WIDTH_IN * 0.55), dpi=300)
     fig.patch.set_facecolor("white")
 
@@ -462,7 +476,14 @@ def generate_tps_baseline_figure(
         print("Not enough face images, skipping TPS baseline figure")
         return
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     size = 512
 
     fig, axes = plt.subplots(

--- a/scripts/generate_html_report.py
+++ b/scripts/generate_html_report.py
@@ -153,7 +153,14 @@ def generate_html(
         html += "<table>\n<tr><th>Procedure</th><th>SSIM</th>"
         html += "<th>LPIPS</th><th>NME</th>"
         html += "<th>ArcFace</th><th>N</th></tr>\n"
-        for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for proc in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             vals = per_proc.get(proc, {})
             if not vals:
                 continue

--- a/scripts/generate_metadata.py
+++ b/scripts/generate_metadata.py
@@ -24,7 +24,14 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def infer_procedure(prefix: str) -> str:

--- a/scripts/generate_pairs_scaled.py
+++ b/scripts/generate_pairs_scaled.py
@@ -101,7 +101,14 @@ def main():
     if existing > 0:
         print(f"Found {existing} existing pairs, continuing from {existing}")
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     rng = np.random.default_rng(args.seed)
 
     # Build work items: cycle through images × random procedures

--- a/scripts/generate_paper_tables.py
+++ b/scripts/generate_paper_tables.py
@@ -287,7 +287,14 @@ def generate_table4_procedures(
     if not proc_data:
         return "% No per-procedure data available"
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     proc_labels = {
         "rhinoplasty": "Rhinoplasty",
         "blepharoplasty": "Blepharoplasty",
@@ -367,7 +374,14 @@ def generate_displacement_table(
     ]
 
     total = 0
-    for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+    for proc in [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]:
         if proc not in procedures:
             continue
         pd = procedures[proc]

--- a/scripts/generate_qualitative_figure.py
+++ b/scripts/generate_qualitative_figure.py
@@ -99,7 +99,14 @@ def generate_main_figure(
     for f in comp_files:
         name = f.stem.replace("_comparison", "")
         proc = "unknown"
-        for p in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for p in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             if p in name:
                 proc = p
                 break
@@ -326,7 +333,14 @@ if __name__ == "__main__":
     )
 
     # Per-procedure details
-    for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+    for proc in [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]:
         generate_procedure_detail(
             args.eval_images,
             str(out / "detail"),

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -29,7 +29,14 @@ import numpy as np
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 FITZ_COLORS = {
     "I": "#FAD6A5",
     "II": "#E8C298",

--- a/scripts/generate_synthetic_pairs.py
+++ b/scripts/generate_synthetic_pairs.py
@@ -96,7 +96,14 @@ def main():
         "--procedure",
         type=str,
         required=True,
-        choices=["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"],
+        choices=[
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
         help="Procedure to generate pairs for",
     )
     parser.add_argument("--target", type=int, default=50000, help="Target number of pairs")

--- a/scripts/hyperparameter_sensitivity.py
+++ b/scripts/hyperparameter_sensitivity.py
@@ -292,7 +292,14 @@ def main():
     parser.add_argument(
         "--procedure",
         default="rhinoplasty",
-        choices=["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"],
+        choices=[
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     parser.add_argument(
         "--sweep",

--- a/scripts/intensity_sweep.py
+++ b/scripts/intensity_sweep.py
@@ -91,7 +91,14 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # All six supported surgical procedures
 # ---------------------------------------------------------------------------
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 # ---------------------------------------------------------------------------
 # Checkpoint auto-discovery order (most preferred first)

--- a/scripts/json_to_latex.py
+++ b/scripts/json_to_latex.py
@@ -17,7 +17,14 @@ import argparse
 import json
 from pathlib import Path
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 PROCEDURE_NAMES = {
     "rhinoplasty": "Rhinoplasty",
     "blepharoplasty": "Blepharoplasty",

--- a/scripts/landmark_accuracy_heatmap.py
+++ b/scripts/landmark_accuracy_heatmap.py
@@ -365,7 +365,14 @@ def main():
 
         # Determine procedure
         proc = "unknown"
-        for p in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for p in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             if p in prefix:
                 proc = p
                 break

--- a/scripts/pi_demo.py
+++ b/scripts/pi_demo.py
@@ -109,8 +109,22 @@ def make_figure_2_procedures(
 ) -> None:
     """Figure 2: All 6 procedures side by side."""
     s = 200
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
-    short_names = ["Rhinoplasty", "Blepharoplasty", "Rhytidectomy", "Orthognathic", "Brow Lift", "Mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
+    short_names = [
+        "Rhinoplasty",
+        "Blepharoplasty",
+        "Rhytidectomy",
+        "Orthognathic",
+        "Brow Lift",
+        "Mentoplasty",
+    ]
 
     cols = [put_label(resize_sq(image, s), "Original")]
 
@@ -178,7 +192,14 @@ def make_figure_4_multi_face(
 ) -> None:
     """Figure 4: Multiple faces x all procedures grid."""
     s = 160
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     rows = []
 
     for name, image, face in images:

--- a/scripts/process_real_pairs.py
+++ b/scripts/process_real_pairs.py
@@ -98,7 +98,14 @@ def process_directory(
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     total_processed = 0
     total_faces = 0
 

--- a/scripts/process_real_surgery.py
+++ b/scripts/process_real_surgery.py
@@ -123,7 +123,14 @@ def main():
     all_pairs = []
     pair_idx = 0
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
 
     for proc in procedures:
         proc_dir = raw_dir / proc

--- a/scripts/profile_pipeline.py
+++ b/scripts/profile_pipeline.py
@@ -127,7 +127,14 @@ def profile_manipulation(face, repeats: int = 10) -> dict:
     """Profile landmark manipulation."""
     from landmarkdiff.manipulation import apply_procedure_preset
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     results = {}
 
     for proc in procedures:
@@ -179,7 +186,14 @@ def profile_masking(face, repeats: int = 10) -> dict:
     """Profile surgical mask generation."""
     from landmarkdiff.masking import generate_surgical_mask
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     results = {}
 
     for proc in procedures:

--- a/scripts/progressive_denoising.py
+++ b/scripts/progressive_denoising.py
@@ -279,7 +279,14 @@ def main():
     for inp_file in input_files:
         prefix = inp_file.stem.replace("_input", "")
         proc = "unknown"
-        for p in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for p in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             if p in prefix:
                 proc = p
                 break
@@ -295,7 +302,14 @@ def main():
             if inp_file not in [s[0] for s in selected_files]:
                 prefix = inp_file.stem.replace("_input", "")
                 proc = "unknown"
-                for p in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+                for p in [
+                    "rhinoplasty",
+                    "blepharoplasty",
+                    "rhytidectomy",
+                    "orthognathic",
+                    "brow_lift",
+                    "mentoplasty",
+                ]:
                     if p in prefix:
                         proc = p
                         break

--- a/scripts/project_status.py
+++ b/scripts/project_status.py
@@ -195,7 +195,8 @@ def format_dashboard(
             "  7. Safety Validation      [identity + bounds]",
             "",
             "--- Supported Procedures ---",
-            "  rhinoplasty | blepharoplasty | rhytidectomy | orthognathic | brow_lift | mentoplasty",
+            "  rhinoplasty | blepharoplasty | rhytidectomy"
+            " | orthognathic | brow_lift | mentoplasty",
             "",
             "=" * 60,
         ]

--- a/scripts/reconstruct_metadata.py
+++ b/scripts/reconstruct_metadata.py
@@ -32,7 +32,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 BASE = Path(__file__).resolve().parent.parent / "data"
 COMBINED = BASE / "training_combined"
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def count_valid_pairs(directory: Path) -> int:

--- a/scripts/run_ablation.py
+++ b/scripts/run_ablation.py
@@ -213,7 +213,14 @@ def evaluate_ablation(
 
             # Infer procedure
             procedure = "rhinoplasty"
-            for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+            for proc in [
+                "rhinoplasty",
+                "blepharoplasty",
+                "rhytidectomy",
+                "orthognathic",
+                "brow_lift",
+                "mentoplasty",
+            ]:
                 if proc in prefix:
                     procedure = proc
                     break

--- a/scripts/run_ablation_experiments.py
+++ b/scripts/run_ablation_experiments.py
@@ -53,7 +53,14 @@ from landmarkdiff.manipulation import apply_procedure_preset
 from landmarkdiff.masking import generate_surgical_mask
 from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def load_test_images(test_dir: str, max_samples: int = 0) -> list[dict]:

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -59,7 +59,14 @@ from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
 logger = logging.getLogger(__name__)
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def load_test_set(test_dir: Path, max_samples: int = 0) -> list[dict]:

--- a/scripts/run_full_demo.py
+++ b/scripts/run_full_demo.py
@@ -53,7 +53,14 @@ def run(
         num_images: Number of images to process
     """
     if procedures is None:
-        procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        procedures = [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]
 
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
@@ -189,7 +196,14 @@ if __name__ == "__main__":
         "--procedures",
         type=str,
         nargs="+",
-        choices=["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"],
+        choices=[
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
         default=None,
         help="Procedures to apply (default: all 6)",
     )

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -85,7 +85,14 @@ def run_all(
     pipe.load()
     print()
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
 
     if image_path:
         images = [image_path]

--- a/scripts/run_tps_ablation.py
+++ b/scripts/run_tps_ablation.py
@@ -30,7 +30,14 @@ from landmarkdiff.manipulation import apply_procedure_preset
 from landmarkdiff.masking import generate_surgical_mask
 from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 DEFAULT_INTENSITY = 65.0
 
 

--- a/scripts/split_dataset.py
+++ b/scripts/split_dataset.py
@@ -33,7 +33,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 logger = logging.getLogger(__name__)
 
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 
 def load_metadata(data_dir: Path) -> dict:

--- a/scripts/uncertainty_estimation.py
+++ b/scripts/uncertainty_estimation.py
@@ -247,7 +247,14 @@ def main():
     for inp_file in input_files:
         prefix = inp_file.stem.replace("_input", "")
         proc = "unknown"
-        for p in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for p in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             if p in prefix:
                 proc = p
                 break

--- a/scripts/update_paper_tables.py
+++ b/scripts/update_paper_tables.py
@@ -139,7 +139,14 @@ def bold_best(
 # ====================================================================
 
 # The canonical order of procedures in Table 1
-PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 # Sample sizes per procedure (from baseline_results.json, also hardcoded in
 # the LaTeX template).  Will be overridden from actual data if available.

--- a/scripts/verify_pipeline.py
+++ b/scripts/verify_pipeline.py
@@ -119,7 +119,14 @@ class PipelineVerifier:
         try:
             from landmarkdiff.manipulation import apply_procedure_preset
 
-            for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+            for proc in [
+                "rhinoplasty",
+                "blepharoplasty",
+                "rhytidectomy",
+                "orthognathic",
+                "brow_lift",
+                "mentoplasty",
+            ]:
                 result = apply_procedure_preset(face, proc, 50.0, image_size=512)
                 manip_landmarks = result.landmarks
                 self.check(
@@ -156,7 +163,14 @@ class PipelineVerifier:
         try:
             from landmarkdiff.masking import generate_surgical_mask
 
-            for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+            for proc in [
+                "rhinoplasty",
+                "blepharoplasty",
+                "rhytidectomy",
+                "orthognathic",
+                "brow_lift",
+                "mentoplasty",
+            ]:
                 mask = generate_surgical_mask(face, proc)
                 self.check(
                     f"mask_{proc}_shape",

--- a/scripts/visualize_displacements.py
+++ b/scripts/visualize_displacements.py
@@ -349,7 +349,14 @@ def create_comparison_figure(
 ) -> None:
     """Create a 4-panel comparison figure for the paper."""
     panels = []
-    for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+    for proc in [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]:
         if proc in model.procedures:
             panel = create_procedure_visualization(model, proc, size)
             panels.append(panel)
@@ -388,7 +395,14 @@ def create_magnitude_chart(
         "Chin": [152, 377, 400, 378, 379, 365, 397, 288, 361],
     }
 
-    procedures = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+    procedures = [
+        "rhinoplasty",
+        "blepharoplasty",
+        "rhytidectomy",
+        "orthognathic",
+        "brow_lift",
+        "mentoplasty",
+    ]
     fig, axes = plt.subplots(1, len(procedures), figsize=(16, 5), sharey=True)
 
     for ax, proc in zip(axes, procedures):

--- a/tests/test_ablation_metadata.py
+++ b/tests/test_ablation_metadata.py
@@ -261,7 +261,14 @@ class TestCurriculumDDP:
 
         curriculum = ProcedureCurriculum(total_steps=1000)
         for i in range(n_samples):
-            proc = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"][i % 6]
+            proc = [
+                "rhinoplasty",
+                "blepharoplasty",
+                "rhytidectomy",
+                "orthognathic",
+                "brow_lift",
+                "mentoplasty",
+            ][i % 6]
             weights[i] = curriculum.get_weight(500, proc)
         assert weights.shape == (n_samples,)
         assert weights.min() > 0  # No zero weights

--- a/tests/test_curriculum_benchmark.py
+++ b/tests/test_curriculum_benchmark.py
@@ -72,7 +72,14 @@ class TestProcedureCurriculum:
 
         pc = ProcedureCurriculum(total_steps=10000)
         for step in range(0, 10001, 1000):
-            for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+            for proc in [
+                "rhinoplasty",
+                "blepharoplasty",
+                "rhytidectomy",
+                "orthognathic",
+                "brow_lift",
+                "mentoplasty",
+            ]:
                 w = pc.get_weight(step, proc)
                 assert 0.1 <= w <= 1.0, f"Weight out of bounds for {proc} at step {step}: {w}"
 
@@ -104,7 +111,14 @@ class TestDataSplitting:
     def mock_dataset(self, tmp_path):
         """Create a mock dataset with multiple procedures."""
         rng = np.random.default_rng(42)
-        for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for proc in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             for i in range(20):
                 prefix = f"{proc}_{i:03d}"
                 img = rng.integers(0, 255, (64, 64, 3), dtype=np.uint8)

--- a/tests/test_data_version.py
+++ b/tests/test_data_version.py
@@ -38,7 +38,14 @@ class TestFileEntry:
         assert entry.procedure == "rhinoplasty"
 
     def test_procedure_inference(self, tmp_path):
-        for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for proc in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             f = tmp_path / f"{proc}_test.png"
             f.write_bytes(b"x")
             entry = FileEntry.from_path(f, base_dir=tmp_path)

--- a/tests/test_deep_dive.py
+++ b/tests/test_deep_dive.py
@@ -714,7 +714,14 @@ class TestIdentityLossComputation:
         loss._has_arcface = False
         pred = torch.rand(4, 3, 64, 64)
         target = torch.rand(4, 3, 64, 64)
-        for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for proc in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             result = loss(pred, target, procedure=proc)
             assert torch.isfinite(result), f"Loss not finite for {proc}"
 
@@ -833,7 +840,15 @@ class TestCombinedLossWithIdentity:
         assert losses["identity"].item() == pytest.approx(0.0, abs=1e-7)
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_combined_with_each_procedure(self, procedure):
         combined = CombinedLoss(phase="B")

--- a/tests/test_exhaustive.py
+++ b/tests/test_exhaustive.py
@@ -667,7 +667,15 @@ class TestGaussianRBFDeform:
 
 class TestApplyProcedurePreset:
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_all_procedures_work(self, face, procedure):
         result = apply_procedure_preset(face, procedure, intensity=50.0)
@@ -718,21 +726,45 @@ class TestApplyProcedurePreset:
         np.testing.assert_array_equal(face.landmarks, original)
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_procedure_landmarks_exist(self, procedure):
         assert procedure in PROCEDURE_LANDMARKS
         assert len(PROCEDURE_LANDMARKS[procedure]) > 0
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_procedure_radius_exists(self, procedure):
         assert procedure in PROCEDURE_RADIUS
         assert PROCEDURE_RADIUS[procedure] > 0
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_procedure_landmark_indices_valid(self, procedure):
         for idx in PROCEDURE_LANDMARKS[procedure]:
@@ -746,13 +778,29 @@ class TestApplyProcedurePreset:
 
 class TestMaskConfig:
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_config_exists(self, procedure):
         assert procedure in MASK_CONFIG
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_config_has_required_keys(self, procedure):
         config = MASK_CONFIG[procedure]
@@ -761,20 +809,44 @@ class TestMaskConfig:
         assert "feather_sigma" in config
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_indices_valid(self, procedure):
         for idx in MASK_CONFIG[procedure]["landmark_indices"]:
             assert 0 <= idx < 478
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_dilation_positive(self, procedure):
         assert MASK_CONFIG[procedure]["dilation_px"] > 0
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_sigma_positive(self, procedure):
         assert MASK_CONFIG[procedure]["feather_sigma"] > 0
@@ -782,7 +854,15 @@ class TestMaskConfig:
 
 class TestGenerateSurgicalMask:
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_all_procedures(self, face, procedure):
         mask = generate_surgical_mask(face, procedure, 512, 512)
@@ -794,7 +874,15 @@ class TestGenerateSurgicalMask:
             generate_surgical_mask(face, "invalid", 512, 512)
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_output_range(self, face, procedure):
         mask = generate_surgical_mask(face, procedure, 512, 512)
@@ -802,14 +890,30 @@ class TestGenerateSurgicalMask:
         assert mask.max() <= 1.0
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_mask_has_nonzero(self, face, procedure):
         mask = generate_surgical_mask(face, procedure, 512, 512)
         assert np.any(mask > 0)
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_mask_has_full_values(self, face, procedure):
         mask = generate_surgical_mask(face, procedure, 512, 512)
@@ -1073,7 +1177,14 @@ class TestPipelineInit:
         assert pipe.mode == mode
 
     def test_procedure_prompts_exist(self):
-        for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for proc in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             assert proc in PROCEDURE_PROMPTS
             assert len(PROCEDURE_PROMPTS[proc]) > 0
 
@@ -2082,7 +2193,15 @@ class TestCrossModuleConsistency:
     """Verify consistency across modules."""
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_mask_config_matches_procedure_landmarks(self, procedure):
         """Mask and manipulation should use same procedure names."""
@@ -2090,7 +2209,15 @@ class TestCrossModuleConsistency:
         assert procedure in PROCEDURE_LANDMARKS
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_procedure_prompts_exist(self, procedure):
         assert procedure in PROCEDURE_PROMPTS
@@ -2140,7 +2267,15 @@ class TestEndToEndPipeline:
         assert conditioning.shape == (512, 512, 3)
 
     @pytest.mark.parametrize(
-        "procedure", ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+        "procedure",
+        [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ],
     )
     def test_all_procedures_pipeline(self, face, procedure):
         manipulated = apply_procedure_preset(face, procedure, 50.0)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,7 +24,14 @@ from landmarkdiff.masking import generate_surgical_mask
 from landmarkdiff.synthetic.tps_warp import warp_image_tps
 
 # Procedures supported by the masking module
-MASKABLE_PROCEDURES = ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]
+MASKABLE_PROCEDURES = [
+    "rhinoplasty",
+    "blepharoplasty",
+    "rhytidectomy",
+    "orthognathic",
+    "brow_lift",
+    "mentoplasty",
+]
 
 # All 6 procedures for manipulation tests
 ALL_PROCEDURES = [

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -80,7 +80,14 @@ class TestEndToEndPipeline:
         if face is None:
             pytest.skip("No face detected")
 
-        for proc in ["rhinoplasty", "blepharoplasty", "rhytidectomy", "orthognathic", "brow_lift", "mentoplasty"]:
+        for proc in [
+            "rhinoplasty",
+            "blepharoplasty",
+            "rhytidectomy",
+            "orthognathic",
+            "brow_lift",
+            "mentoplasty",
+        ]:
             manip = apply_procedure_preset(face, proc, 65.0, image_size=512)
             assert manip is not None
             assert manip.pixel_coords.shape == face.pixel_coords.shape


### PR DESCRIPTION
## Summary
- PR #268 added brow_lift and mentoplasty to all default procedure lists across 47 files
- This pushed many lines over the 100-char ruff E501 limit (78 errors)
- Applied ruff format to break long lines properly
- Manually split one string literal in project_status.py that ruff format could not handle

## Test plan
- [x] `ruff check` passes (0 errors, was 78)
- [x] `ruff format --check` passes (223 files formatted)
- CI should go fully green after merge