### PR TITLE
Add Docker GPU support and deployment docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,8 @@ Thanks to everyone who has contributed to LandmarkDiff.
 |------------|---------------|
 | [Deepak8858](https://github.com/Deepak8858) | Brow lift procedure preset ([#35](https://github.com/dreamlessx/LandmarkDiff-public/pull/35)) |
 | [P-r-e-m-i-u-m](https://github.com/P-r-e-m-i-u-m) | Mentoplasty procedure preset ([#36](https://github.com/dreamlessx/LandmarkDiff-public/pull/36)) |
+| [lshariprasad](https://github.com/lshariprasad) | histogram_match_skin tests ([#263](https://github.com/dreamlessx/LandmarkDiff-public/pull/263)) |
+| [dagangtj](https://github.com/dagangtj) | SafetyResult dataclass improvements ([#235](https://github.com/dreamlessx/LandmarkDiff-public/pull/235)), file logging handler ([#236](https://github.com/dreamlessx/LandmarkDiff-public/pull/236)), api_client error messages ([#237](https://github.com/dreamlessx/LandmarkDiff-public/pull/237)) |
 | [passionworkeer](https://github.com/passionworkeer) | Docker architecture feedback ([#5](https://github.com/dreamlessx/LandmarkDiff-public/issues/5)) |
 
 ## Data Contributors


### PR DESCRIPTION
## Summary

- Add `Dockerfile.gpu` based on `nvidia/cuda:12.1.1-runtime-ubuntu22.04` for GPU inference with a smaller image footprint than the existing devel-based `Dockerfile`
- Add `gpu` service to `docker-compose.yml` on port 7861, keeping the existing `app-gpu` service for backward compatibility
- Add `docs/docker-gpu.md` with comprehensive GPU Docker setup guide covering NVIDIA Container Toolkit installation, VRAM requirements by GPU tier (8GB/12GB/24GB+), verification steps, multi-GPU configuration, and troubleshooting
- Update README, `docs/index.md`, `docs/install.md`, and `docs/tutorials/deployment.md` to reference the new GPU guide

Closes #232

## Test plan

- [ ] `docker build -f Dockerfile.gpu -t landmarkdiff:gpu .` builds successfully
- [ ] `docker compose up gpu` starts the GPU service on port 7861
- [ ] `docker run --gpus all landmarkdiff:gpu python -c "import torch; print(torch.cuda.is_available())"` returns True
- [ ] Links in README, install.md, index.md, and deployment.md resolve correctly
- [ ] `docs/docker-gpu.md` renders properly in Sphinx/GitHub