### PR TITLE
Use weights_only=True for all torch.load calls

### DIFF
--- a/scripts/check_checkpoint.py
+++ b/scripts/check_checkpoint.py
@@ -137,7 +137,7 @@ def check_optimizer(ckpt_dir: Path) -> dict:
             "detail": f"{len(shards)} optimizer shard(s) found",
         }
     try:
-        opt_state = torch.load(optimizer_path, map_location="cpu", weights_only=False)
+        opt_state = torch.load(optimizer_path, map_location="cpu", weights_only=True)
         n_groups = len(opt_state.get("param_groups", []))
         return {
             "found": True,

--- a/scripts/reproduce_experiment.py
+++ b/scripts/reproduce_experiment.py
@@ -27,7 +27,7 @@ def load_checkpoint_metadata(checkpoint_path: Path) -> dict:
     import torch
 
     # Only load metadata keys, not the full state dict
-    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
 
     meta = {}
     if "metadata" in ckpt:
@@ -110,7 +110,7 @@ def run_evaluation(checkpoint_path: Path, config: ExperimentConfig) -> dict:
     import torch
 
     print(f"  Loading checkpoint: {checkpoint_path.name}")
-    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
 
     # Basic evaluation metrics
     metrics = ckpt.get("metrics", {})


### PR DESCRIPTION
## Summary

- Switch 3 remaining `torch.load(weights_only=False)` calls to `weights_only=True` in:
  - `scripts/check_checkpoint.py` (optimizer state loading)
  - `scripts/reproduce_experiment.py` (checkpoint metadata and evaluation loading)
- This follows PyTorch security best practice to prevent arbitrary code execution during deserialization

## Diagnostics run

- **mypy**: 38 source files, 0 errors
- **ruff check**: All checks passed
- **ruff format**: 165 files unchanged
- **AST scan**: All torch.load() calls confirmed to use `weights_only=True`
- **No hardcoded paths** (agarwm5, accrepfs, etc.)
- **No debug artifacts** (breakpoint, pdb, DEBUG prints)
- **No TODO/FIXME/HACK** comments in landmarkdiff/

## Test plan

- [ ] CI lint, type-check, and test jobs pass
- [ ] Checkpoint loading scripts still work with standard LandmarkDiff checkpoints