### PR TITLE
Validate displacement model on load

### DIFF
--- a/landmarkdiff/displacement_model.py
+++ b/landmarkdiff/displacement_model.py
@@ -636,6 +636,19 @@ class DisplacementModel:
         else:
             raise ValueError(f"Unrecognized displacement model format. Keys: {data.files[:10]}")
 
+        # Validate loaded model is not empty
+        if not model.stats:
+            raise ValueError(
+                f"Displacement model at {path} contains no procedure data. "
+                f"File may be corrupted or empty. Keys found: {data.files[:10]}"
+            )
+        for proc, stats in model.stats.items():
+            if not stats:
+                raise ValueError(
+                    f"Displacement model at {path} has no statistics for "
+                    f"procedure '{proc}'. File may be corrupted."
+                )
+
         model._fitted = True
         logger.info(
             "Loaded displacement model from %s (%d procedures, %s samples)",


### PR DESCRIPTION
## Summary
- Adds validation after loading displacement model from `.npz` file
- Raises `ValueError` if the file contains no procedure data or has empty statistics, instead of silently returning a zero-initialized model
- Guards against corrupted or truncated `.npz` files

Fixes #113

## Test plan
- [ ] Load a valid displacement model, should work as before
- [ ] Create an empty `.npz` and try to load, should raise `ValueError`
- [ ] Create an `.npz` with `__metadata__` but no procedure arrays, should raise `ValueError`