### PR TITLE
Add rescale support for FaceLandmarks

### DIFF
--- a/landmarkdiff/landmarks.py
+++ b/landmarkdiff/landmarks.py
@@ -176,6 +176,30 @@ class FaceLandmarks:
         coords[:, 1] *= self.image_height
         return coords
 
+    def pixel_coords_at(self, width: int, height: int) -> np.ndarray:
+        """Convert normalized landmarks to pixel coordinates at a given size.
+
+        Use this when the image has been resized after landmark extraction.
+        """
+        coords = self.landmarks[:, :2].copy()
+        coords[:, 0] *= width
+        coords[:, 1] *= height
+        return coords
+
+    def rescale(self, width: int, height: int) -> FaceLandmarks:
+        """Return a copy with updated image dimensions.
+
+        Landmarks stay in normalized [0,1] space; only the stored
+        width/height change, so ``pixel_coords`` returns values at
+        the new resolution.
+        """
+        return FaceLandmarks(
+            landmarks=self.landmarks.copy(),
+            image_width=width,
+            image_height=height,
+            confidence=self.confidence,
+        )
+
     def get_region(self, region: str) -> np.ndarray:
         """Get landmark indices for a named region."""
         indices = LANDMARK_REGIONS.get(region, [])


### PR DESCRIPTION
## Summary
- Adds `pixel_coords_at(width, height)` method to get pixel coordinates at any resolution
- Adds `rescale(width, height)` method that returns a copy with updated dimensions
- Fixes the issue where `pixel_coords` returns wrong-scale values after the image is resized

Fixes #109

## Test plan
- [ ] Call `pixel_coords_at(1024, 1024)` on landmarks extracted from a 512x512 image, coordinates should be 2x the original
- [ ] Call `rescale(256, 256).pixel_coords`, should return coordinates at 256x256 scale
- [ ] Original object unchanged after `rescale()` call