### PR TITLE
Guard against NaN ArcFace scores on occluded faces

### DIFF
--- a/landmarkdiff/face_verifier.py
+++ b/landmarkdiff/face_verifier.py
@@ -709,7 +709,11 @@ def get_face_embedding(image: np.ndarray) -> np.ndarray | None:
     try:
         faces = app.get(image)
         if faces:
-            return faces[0].embedding
+            emb = faces[0].embedding
+            if np.linalg.norm(emb) < 1e-6:
+                logger.warning("ArcFace returned near-zero embedding (occluded face?)")
+                return None
+            return emb
     except Exception:
         pass
     return None


### PR DESCRIPTION
## Summary
- Checks embedding norm before returning from `get_face_embedding()`
- Returns `None` (with a warning log) when ArcFace produces a near-zero embedding, which happens with partially occluded faces
- Prevents downstream `NaN` similarity scores in `verify_identity()`

Fixes #129

## Test plan
- [ ] Normal face image returns valid embedding and similarity score
- [ ] `verify_identity()` with `None` embedding returns `(-1.0, True)` as before