### PR TITLE
Lower default ArcFace identity threshold from 0.6 to 0.5

### DIFF
--- a/landmarkdiff/config.py
+++ b/landmarkdiff/config.py
@@ -140,7 +140,7 @@ class InferenceConfig:
 
     # Identity verification
     verify_identity: bool = True
-    identity_threshold: float = 0.6
+    identity_threshold: float = 0.5
 
 
 @dataclass
@@ -187,7 +187,7 @@ class SlurmConfig:
 class SafetyConfig:
     """Clinical safety and responsible AI parameters."""
 
-    identity_threshold: float = 0.6
+    identity_threshold: float = 0.5
     max_displacement_fraction: float = 0.05
     watermark_enabled: bool = True
     watermark_text: str = "AI-GENERATED PREDICTION"

--- a/landmarkdiff/face_verifier.py
+++ b/landmarkdiff/face_verifier.py
@@ -722,12 +722,12 @@ def get_face_embedding(image: np.ndarray) -> np.ndarray | None:
 def verify_identity(
     original: np.ndarray,
     restored: np.ndarray,
-    threshold: float = 0.6,
+    threshold: float = 0.5,
 ) -> tuple[float, bool]:
     """Compare identity between original and restored using ArcFace.
 
     Returns (cosine_similarity, passed).
-    Similarity > threshold means same person (threshold=0.6 is conservative).
+    Similarity > threshold means same person (0.5 accommodates non-frontal poses).
     """
     emb_orig = get_face_embedding(original)
     emb_rest = get_face_embedding(restored)
@@ -750,11 +750,11 @@ def verify_identity(
 def verify_and_restore(
     image: np.ndarray,
     quality_threshold: float = 60.0,
-    identity_threshold: float = 0.6,
+    identity_threshold: float = 0.5,
     restore_mode: str = "auto",
     codeformer_fidelity: float = 0.7,
 ) -> RestorationResult:
-    """Full pipeline: analyze → restore → verify identity.
+    """Full pipeline: analyze -> restore -> verify identity.
 
     This is the main entry point for the face verifier. It:
     1. Analyzes the input for distortions
@@ -837,7 +837,7 @@ def verify_batch(
     image_dir: str,
     output_dir: str | None = None,
     quality_threshold: float = 60.0,
-    identity_threshold: float = 0.6,
+    identity_threshold: float = 0.5,
     restore_mode: str = "auto",
     save_rejected: bool = False,
     extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png", ".webp", ".bmp"),

--- a/landmarkdiff/postprocess.py
+++ b/landmarkdiff/postprocess.py
@@ -365,19 +365,19 @@ def enhance_background_realesrgan(
 def verify_identity_arcface(
     original: np.ndarray,
     result: np.ndarray,
-    threshold: float = 0.6,
+    threshold: float = 0.5,
 ) -> dict:
     """Verify output preserves input identity using ArcFace neural net.
 
     Computes cosine similarity between ArcFace embeddings of the original
     and result images. If similarity drops below threshold, flags identity
-    drift — meaning the postprocessing or diffusion altered the person's
+    drift -- meaning the postprocessing or diffusion altered the person's
     appearance too much.
 
     Args:
         original: BGR original face image.
         result: BGR post-processed output image.
-        threshold: Minimum cosine similarity to pass (0.6 = same person).
+        threshold: Minimum cosine similarity to pass (0.5 = same person).
 
     Returns:
         Dict with 'similarity' (float), 'passed' (bool), 'message' (str).
@@ -514,7 +514,7 @@ def full_postprocess(
     use_laplacian_blend: bool = True,
     sharpen_strength: float = 0.25,
     verify_identity: bool = True,
-    identity_threshold: float = 0.6,
+    identity_threshold: float = 0.5,
 ) -> dict:
     """Full neural net + classical post-processing pipeline for maximum photorealism.
 

--- a/landmarkdiff/safety.py
+++ b/landmarkdiff/safety.py
@@ -86,7 +86,7 @@ class SafetyValidator:
 
     def __init__(
         self,
-        identity_threshold: float = 0.6,
+        identity_threshold: float = 0.5,
         max_displacement_fraction: float = 0.05,
         min_face_confidence: float = 0.5,
         max_yaw_degrees: float = 45.0,

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -43,7 +43,7 @@ def sample_cases():
             safety_passed=False,
             identity_sim=0.45,
             fitzpatrick_type="V-VI",
-            failures=["Identity similarity 0.45 below threshold 0.6"],
+            failures=["Identity similarity 0.45 below threshold 0.5"],
         ),
         AuditCase(
             case_id="P005",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,7 +84,7 @@ class TestDataclasses:
 
     def test_safety_config_defaults(self):
         cfg = SafetyConfig()
-        assert cfg.identity_threshold == 0.6
+        assert cfg.identity_threshold == 0.5
         assert cfg.watermark_enabled is True
         assert cfg.min_face_confidence == 0.5
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -290,7 +290,7 @@ class TestYAMLEdgeCases:
         cfg = ExperimentConfig.from_yaml(yaml_path)
         assert cfg.training.learning_rate == 1e-5
         assert cfg.model.base_model == "runwayml/stable-diffusion-v1-5"
-        assert cfg.safety.identity_threshold == 0.6
+        assert cfg.safety.identity_threshold == 0.5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -51,7 +51,7 @@ class TestSafetyValidator:
     @pytest.fixture
     def validator(self):
         return SafetyValidator(
-            identity_threshold=0.6,
+            identity_threshold=0.5,
             max_displacement_fraction=0.05,
             watermark_enabled=True,
         )


### PR DESCRIPTION
## Summary
- Lower the default identity verification threshold from 0.6 to 0.5 across all modules
- 0.5 is the standard ArcFace verification threshold and better accommodates non-frontal head poses
- Updated: postprocess.py, face_verifier.py, config.py, safety.py, and all related tests
- The threshold remains fully configurable via function parameters and ExperimentConfig

## Test plan
- [ ] Updated tests in test_config.py, test_safety.py, test_config_validation.py, test_audit.py
- [ ] CI green

Fixes #137