### PR TITLE
Add edge anchor points to TPS warp to prevent boundary stretching

### DIFF
--- a/landmarkdiff/synthetic/tps_warp.py
+++ b/landmarkdiff/synthetic/tps_warp.py
@@ -70,6 +70,24 @@ def warp_image_tps(
     # Subsample control points for speed (478 -> ~80)
     src_sub, dst_sub = _subsample_control_points(src_pts, dst_pts)
 
+    # Add edge anchor points to prevent stretching near image boundaries.
+    # These identity-mapped corners and edge midpoints keep the border stable.
+    edge_pts = np.array(
+        [
+            [0, 0],
+            [w - 1, 0],
+            [0, h - 1],
+            [w - 1, h - 1],
+            [w // 2, 0],
+            [w // 2, h - 1],
+            [0, h // 2],
+            [w - 1, h // 2],
+        ],
+        dtype=np.float32,
+    )
+    src_sub = np.vstack([src_sub, edge_pts])
+    dst_sub = np.vstack([dst_sub, edge_pts])
+
     # Compute TPS coefficients on subsampled points
     map_x, map_y = _compute_tps_map(src_sub, dst_sub, w, h)
 


### PR DESCRIPTION
## Summary
- Add 8 identity-mapped edge anchor points (4 corners + 4 edge midpoints) to TPS control point set
- Prevents extreme stretching when deformed landmarks are within ~10px of image boundary
- Anchors keep border pixels in place while allowing interior deformation

## Test plan
- [ ] Run TPS warp with landmarks near image edges
- [ ] Verify no stretching artifacts at corners/edges
- [ ] CI green

Fixes #61