### PR TITLE
Add rotation-aware face bounding box

### DIFF
--- a/landmarkdiff/landmarks.py
+++ b/landmarkdiff/landmarks.py
@@ -222,7 +222,7 @@ class FaceLandmarks:
         right eye outer corner (landmark 263) to estimate roll angle.
         Returns degrees counter-clockwise; 0 means upright.
         """
-        left_eye = self.landmarks[33, :2]   # left eye outer corner
+        left_eye = self.landmarks[33, :2]  # left eye outer corner
         right_eye = self.landmarks[263, :2]  # right eye outer corner
         dx = (right_eye[0] - left_eye[0]) * self.image_width
         dy = (right_eye[1] - left_eye[1]) * self.image_height

--- a/tests/test_landmarks_extended.py
+++ b/tests/test_landmarks_extended.py
@@ -194,7 +194,10 @@ class TestFaceBbox:
         lm_up[33] = [0.3, 0.4, 0.0]
         lm_up[263] = [0.7, 0.4, 0.0]  # eyes level
         face_up = FaceLandmarks(
-            landmarks=lm_up, image_width=512, image_height=512, confidence=1.0,
+            landmarks=lm_up,
+            image_width=512,
+            image_height=512,
+            confidence=1.0,
         )
 
         # Rotated face (same landmarks, eyes tilted 30+ degrees)
@@ -202,7 +205,10 @@ class TestFaceBbox:
         lm_rot[33] = [0.3, 0.3, 0.0]
         lm_rot[263] = [0.7, 0.6, 0.0]  # strong tilt
         face_rot = FaceLandmarks(
-            landmarks=lm_rot, image_width=512, image_height=512, confidence=1.0,
+            landmarks=lm_rot,
+            image_width=512,
+            image_height=512,
+            confidence=1.0,
         )
 
         bbox_up = face_up.face_bbox


### PR DESCRIPTION
Fixes #73

Adds two new properties to `FaceLandmarks`:

- **`face_rotation`**: estimates in-plane roll angle (degrees) from the line between eye outer corners (landmarks 33 and 263). Returns 0 for upright faces.

- **`face_bbox`**: returns an axis-aligned bounding box `(x_min, y_min, x_max, y_max)` with 20% base padding. For rotated faces (>10 degrees), padding increases by 1% per degree of rotation beyond 10, preventing tight crops from cutting off parts of the face.

Both properties are computed lazily from existing landmark data with no external dependencies.