### PR TITLE
Close wireframe gaps at jawline during high-intensity deformation

### DIFF
--- a/landmarkdiff/conditioning.py
+++ b/landmarkdiff/conditioning.py
@@ -105,6 +105,9 @@ NOSE_BRIDGE_UPPER = [8, 9, 168, 6, 8]  # close the glabella/nasion gap
 NOSE_TIP = [94, 2, 326, 327, 294, 278, 279, 275, 274, 460, 456, 363, 370]
 NOSE_BOTTOM = [19, 1, 274, 275, 440, 344, 278, 294, 460, 305, 289, 392]
 
+# Lower jaw fill: connects landmarks 172-177 that JAWLINE_CONTOUR skips
+JAWLINE_LOWER = [172, 173, 174, 175, 176, 177, 152, 400, 378, 379, 365, 397]
+
 OUTER_LIPS = [
     61,
     146,
@@ -162,6 +165,7 @@ _CANNY_DEFAULT_MEDIAN = 128.0  # fallback when no non-zero pixels exist
 
 ALL_CONTOURS = [
     JAWLINE_CONTOUR,
+    JAWLINE_LOWER,
     LEFT_EYE_CONTOUR,
     RIGHT_EYE_CONTOUR,
     LEFT_EYEBROW,

--- a/landmarkdiff/landmarks.py
+++ b/landmarkdiff/landmarks.py
@@ -422,6 +422,10 @@ def render_landmark_image(
         for a, b in [(8, 9), (8, 168), (8, 6), (9, 168)]:
             cv2.line(canvas, tuple(pts[a]), tuple(pts[b]), (192, 192, 192), 1, cv2.LINE_AA)
 
+        # Supplement sparse jawline edges (landmarks 172-177)
+        for a, b in [(172, 173), (173, 174), (174, 175), (175, 176), (176, 177)]:
+            cv2.line(canvas, tuple(pts[a]), tuple(pts[b]), (192, 192, 192), 1, cv2.LINE_AA)
+
     except (ImportError, AttributeError):
         # Fallback: draw colored dots if tessellation not available
         idx_to_color: dict[int, tuple[int, int, int]] = {}

--- a/tests/test_conditioning_extended.py
+++ b/tests/test_conditioning_extended.py
@@ -333,5 +333,5 @@ class TestContourData:
             assert len(contour) >= 2, f"Contour {i} has fewer than 2 points"
 
     def test_total_contour_count(self):
-        """Should have exactly 11 contour groups (includes nose bridge upper)."""
-        assert len(ALL_CONTOURS) == 11
+        """Should have exactly 12 contour groups (includes nose bridge upper and jawline lower)."""
+        assert len(ALL_CONTOURS) == 12

--- a/tests/test_exhaustive.py
+++ b/tests/test_exhaustive.py
@@ -425,7 +425,7 @@ class TestContourData:
         assert NOSE_BOTTOM in ALL_CONTOURS
 
     def test_all_contours_count(self):
-        assert len(ALL_CONTOURS) == 11
+        assert len(ALL_CONTOURS) == 12
 
     @pytest.mark.parametrize("contour", ALL_CONTOURS)
     def test_contour_indices_valid(self, contour):


### PR DESCRIPTION
Fixes #52

Adds supplementary jawline edges to prevent visible gaps when deforming at high intensity (80+):

- New `JAWLINE_LOWER` contour connecting landmarks 172-177 in the static wireframe renderer
- Supplementary edges between consecutive jawline landmarks (172-173-174-175-176-177) in the MediaPipe tessellation rendering