### PR TITLE
Fix create_dataloader dropping last partial batch

### DIFF
--- a/landmarkdiff/data.py
+++ b/landmarkdiff/data.py
@@ -316,10 +316,10 @@ def create_dataloader(
     shuffle: bool = True,
     sampler: Sampler | None = None,
     pin_memory: bool = True,
-    drop_last: bool = True,
+    drop_last: bool = False,
     persistent_workers: bool = False,
 ) -> DataLoader:
-    """Create a DataLoader with sensible defaults for training.
+    """Create a DataLoader with sensible defaults.
 
     Args:
         dataset: PyTorch Dataset.

--- a/scripts/batch_inference.py
+++ b/scripts/batch_inference.py
@@ -265,7 +265,7 @@ def main():
     parser.add_argument("--output", default="results/batch", help="Output directory")
     parser.add_argument("--procedure", default="rhinoplasty", choices=PROCEDURES)
     parser.add_argument(
-        "--all-procedures", action="store_true", help="Run all 4 procedures for each image"
+        "--all-procedures", action="store_true", help="Run all 6 procedures for each image"
     )
     parser.add_argument("--intensity", type=float, default=65.0)
     parser.add_argument(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -304,6 +304,16 @@ class TestCreateDataloader:
         batch = next(iter(loader))
         assert batch["input"].shape == (2, 3, 64, 64)
 
+    def test_default_keeps_last_batch(self, sample_data_dir):
+        """Default drop_last=False should not discard the final partial batch."""
+        ds = SurgicalPairDataset(sample_data_dir, resolution=64)
+        n = len(ds)
+        # Use a batch size that doesn't divide evenly
+        bs = max(2, n - 1) if n > 2 else 2
+        loader = create_dataloader(ds, batch_size=bs, num_workers=0, shuffle=False)
+        total = sum(batch["input"].shape[0] for batch in loader)
+        assert total == n
+
     def test_with_sampler(self, sample_data_dir):
         ds = SurgicalPairDataset(sample_data_dir, resolution=64)
         sampler = create_procedure_sampler(ds)


### PR DESCRIPTION
## Summary
- Change `create_dataloader` default `drop_last` from `True` to `False` so the last incomplete batch is not silently discarded during inference/evaluation
- Training callers already pass `drop_last=True` explicitly, so training behavior is unchanged
- Fix `--all-procedures` help text in batch_inference.py (said "4 procedures", should be "6")

Fixes #134

## Test plan
- [ ] New test `test_default_keeps_last_batch` verifies all samples are yielded
- [ ] Existing tests pass with updated default
- [ ] CI green across Python 3.10/3.11/3.12