### PR TITLE
Warn when controlnet_conditioning_scale used in img2img mode

### DIFF
--- a/landmarkdiff/inference.py
+++ b/landmarkdiff/inference.py
@@ -507,6 +507,12 @@ class LandmarkDiffPipeline:
                     "num_inference_steps or switching to mode='tps' for CPU-only."
                 ) from exc
         else:
+            if controlnet_conditioning_scale != 0.9:
+                logger.warning(
+                    "controlnet_conditioning_scale has no effect in img2img mode "
+                    "(no ControlNet is used). Use mode='controlnet' for "
+                    "conditioning scale control."
+                )
             try:
                 raw_output = self._generate_img2img(
                     tps_warped,


### PR DESCRIPTION
## Summary
- Add warning when `controlnet_conditioning_scale` is set to a non-default value while using img2img mode, since img2img does not use ControlNet
- Helps users discover the misconfiguration and switch to `mode='controlnet'` for conditioning scale control

Fixes #65

## Test plan
- [ ] Warning is logged only when scale != 0.9 and mode is img2img
- [ ] No behavior change for controlnet/tps modes
- [ ] CI green