### PR TITLE
Add deterministic flag for cross-GPU seed reproducibility

### DIFF
--- a/landmarkdiff/cli.py
+++ b/landmarkdiff/cli.py
@@ -45,6 +45,7 @@ def cmd_infer(args: argparse.Namespace) -> None:
         procedure=args.procedure,
         intensity=args.intensity,
         seed=args.seed,
+        deterministic=getattr(args, "deterministic", False),
     )
 
     out_path = Path(args.output)
@@ -188,6 +189,11 @@ def main(argv: list[str] | None = None) -> None:
     p_infer.add_argument("--displacement-model", default=None)
     p_infer.add_argument("--seed", type=int, default=42)
     p_infer.add_argument("--watermark", action="store_true")
+    p_infer.add_argument(
+        "--deterministic",
+        action="store_true",
+        help="Enable fully deterministic mode (slower, but reproducible across GPUs)",
+    )
     p_infer.set_defaults(func=cmd_infer)
 
     # --- ensemble ---

--- a/landmarkdiff/inference.py
+++ b/landmarkdiff/inference.py
@@ -404,9 +404,15 @@ class LandmarkDiffPipeline:
         clinical_flags: ClinicalFlags | None = None,
         postprocess: bool = True,
         use_gfpgan: bool = False,
+        deterministic: bool = False,
     ) -> dict:
         if not self.is_loaded:
             raise RuntimeError("Pipeline not loaded. Call .load() first.")
+
+        if deterministic:
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+            torch.use_deterministic_algorithms(True, warn_only=True)
 
         flags = clinical_flags or self.clinical_flags
         res = _SD15_RESOLUTION
@@ -679,6 +685,7 @@ def run_inference(
     ip_adapter_scale: float = 0.6,
     controlnet_checkpoint: str | None = None,
     displacement_model_path: str | None = None,
+    deterministic: bool = False,
 ) -> None:
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
@@ -697,7 +704,9 @@ def run_inference(
     pipe.load()
 
     logger.info("Generating %s prediction (intensity=%s, mode=%s)", procedure, intensity, mode)
-    result = pipe.generate(image, procedure=procedure, intensity=intensity, seed=seed)
+    result = pipe.generate(
+        image, procedure=procedure, intensity=intensity, seed=seed, deterministic=deterministic
+    )
 
     cv2.imwrite(str(out / "input.png"), result["input"])
     cv2.imwrite(str(out / "output.png"), result["output"])
@@ -739,6 +748,11 @@ if __name__ == "__main__":
         default=None,
         help="Path to displacement_model.npz for data-driven manipulation",
     )
+    parser.add_argument(
+        "--deterministic",
+        action="store_true",
+        help="Enable fully deterministic mode (slower, but reproducible across GPUs)",
+    )
     args = parser.parse_args()
 
     run_inference(
@@ -751,4 +765,5 @@ if __name__ == "__main__":
         args.ip_adapter_scale,
         args.checkpoint,
         args.displacement_model,
+        args.deterministic,
     )


### PR DESCRIPTION
## Summary
- Add `deterministic` parameter to `LandmarkDiffPipeline.generate()` and both CLI entry points
- When enabled, sets `torch.backends.cudnn.deterministic=True`, `cudnn.benchmark=False`, and `torch.use_deterministic_algorithms(warn_only=True)`
- Trades inference speed for bit-exact reproducibility across different GPU architectures (A100 vs 3090 etc.)

Fixes #77

## Test plan
- [ ] `--deterministic` flag accepted by CLI
- [ ] Default behavior unchanged (deterministic=False)
- [ ] CI green across Python 3.10/3.11/3.12