### PR TITLE
Fix memory leak in batch inference from autograd graph retention

### DIFF
--- a/landmarkdiff/inference.py
+++ b/landmarkdiff/inference.py
@@ -391,6 +391,7 @@ class LandmarkDiffPipeline:
     def is_loaded(self) -> bool:
         return self._pipe is not None or self.mode == "tps"
 
+    @torch.no_grad()
     def generate(
         self,
         image: np.ndarray,
@@ -596,7 +597,9 @@ class LandmarkDiffPipeline:
         if ip_adapter_image is not None and self._ip_adapter_loaded:
             kwargs["ip_adapter_image"] = ip_adapter_image
         result = self._pipe(**kwargs)
-        return pil_to_numpy(result.images[0])
+        output = pil_to_numpy(result.images[0])
+        del result
+        return output
 
     def _generate_img2img(
         self,
@@ -617,7 +620,9 @@ class LandmarkDiffPipeline:
             strength=strength,
             generator=generator,
         )
-        return pil_to_numpy(result.images[0])
+        output = pil_to_numpy(result.images[0])
+        del result
+        return output
 
 
 def estimate_face_view(face: FaceLandmarks) -> dict:

--- a/scripts/batch_inference.py
+++ b/scripts/batch_inference.py
@@ -39,6 +39,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import gc
 import json
 import logging
 import sys
@@ -404,6 +405,16 @@ def main():
                     lpips,
                     elapsed,
                 )
+
+        # Free memory between images to prevent accumulation
+        gc.collect()
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except ImportError:
+            pass
 
     total_time = time.time() - t_start
 


### PR DESCRIPTION
## Summary
- Add `@torch.no_grad()` to `LandmarkDiffPipeline.generate()` to prevent autograd graph from holding intermediate tensors across iterations
- Delete pipeline output objects immediately after extracting numpy arrays in `_generate_controlnet` and `_generate_img2img`
- Add `gc.collect()` and `torch.cuda.empty_cache()` between images in `batch_inference.py`

Fixes #53