### PR TITLE
Add input quality warnings for low-res, blurry, and dark images

### DIFF
--- a/landmarkdiff/inference.py
+++ b/landmarkdiff/inference.py
@@ -109,6 +109,41 @@ _YAW_THREE_QUARTER_MAX = 45
 _YAW_WARNING_THRESHOLD = 30
 # Max pitch scale factor (maps pitch ratio to degrees)
 _PITCH_SCALE = 45
+# Input quality thresholds
+_MIN_RESOLUTION = 128  # minimum dimension in pixels
+_BLUR_LAPLACIAN_THRESHOLD = 50.0  # below this variance, image is likely blurry
+_DARK_MEAN_THRESHOLD = 40  # mean brightness below this is poorly lit
+
+
+def check_image_quality(image: np.ndarray) -> list[str]:
+    """Check input image quality and return a list of warning strings.
+
+    Detects low resolution, blur (via Laplacian variance), and poor
+    lighting. Returns an empty list if quality is acceptable.
+    """
+    warnings = []
+    h, w = image.shape[:2]
+
+    if min(h, w) < _MIN_RESOLUTION:
+        warnings.append(
+            f"Low resolution ({w}x{h}): minimum {_MIN_RESOLUTION}px "
+            "recommended for reliable landmark detection"
+        )
+
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if image.ndim == 3 else image
+    lap_var = cv2.Laplacian(gray, cv2.CV_64F).var()
+    if lap_var < _BLUR_LAPLACIAN_THRESHOLD:
+        warnings.append(
+            f"Blurry input (Laplacian variance={lap_var:.1f}): sharp images produce better results"
+        )
+
+    mean_brightness = float(gray.mean())
+    if mean_brightness < _DARK_MEAN_THRESHOLD:
+        warnings.append(
+            f"Dark input (mean brightness={mean_brightness:.0f}/255): well-lit images recommended"
+        )
+
+    return warnings
 
 
 def mask_composite(
@@ -415,6 +450,11 @@ class LandmarkDiffPipeline:
             torch.backends.cudnn.benchmark = False
             torch.use_deterministic_algorithms(True, warn_only=True)
 
+        # Check input quality and warn (non-blocking)
+        quality_warnings = check_image_quality(image)
+        for warning in quality_warnings:
+            logger.warning("Input quality: %s", warning)
+
         flags = clinical_flags or self.clinical_flags
         res = _SD15_RESOLUTION
         image_512 = cv2.resize(image, (res, res))
@@ -578,6 +618,7 @@ class LandmarkDiffPipeline:
             "identity_check": identity_check,
             "restore_used": restore_used,
             "manipulation_mode": manipulation_mode,
+            "quality_warnings": quality_warnings,
         }
 
     def _generate_controlnet(

--- a/tests/test_conditioning_extended.py
+++ b/tests/test_conditioning_extended.py
@@ -6,11 +6,13 @@ and generate_conditioning integration. All tests run without GPU or model loadin
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
 
 import cv2
 import numpy as np
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -352,3 +354,52 @@ class TestContourData:
     def test_total_contour_count(self):
         """Should have exactly 12 contour groups (includes nose bridge upper and jawline lower)."""
         assert len(ALL_CONTOURS) == 12
+
+
+# ---------------------------------------------------------------------------
+# Input quality checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not importlib.util.find_spec("torch"),
+    reason="torch not installed",
+)
+class TestCheckImageQuality:
+    """Tests for check_image_quality input validation."""
+
+    def test_good_image_no_warnings(self):
+        """A sharp, well-lit, high-res image should produce no warnings."""
+        from landmarkdiff.inference import check_image_quality
+
+        # Sharp textured image at decent resolution
+        img = np.zeros((512, 512, 3), dtype=np.uint8)
+        cv2.rectangle(img, (50, 50), (200, 200), (200, 200, 200), 2)
+        cv2.rectangle(img, (250, 250), (400, 400), (150, 150, 150), 2)
+        img[:] = img + 80  # raise brightness
+        warnings = check_image_quality(img)
+        assert isinstance(warnings, list)
+
+    def test_low_resolution_warning(self):
+        """Tiny image should trigger low resolution warning."""
+        from landmarkdiff.inference import check_image_quality
+
+        img = np.full((64, 64, 3), 128, dtype=np.uint8)
+        warnings = check_image_quality(img)
+        assert any("Low resolution" in w for w in warnings)
+
+    def test_dark_image_warning(self):
+        """Nearly black image should trigger dark warning."""
+        from landmarkdiff.inference import check_image_quality
+
+        img = np.full((256, 256, 3), 10, dtype=np.uint8)
+        warnings = check_image_quality(img)
+        assert any("Dark input" in w for w in warnings)
+
+    def test_blurry_image_warning(self):
+        """Flat constant image should trigger blur warning."""
+        from landmarkdiff.inference import check_image_quality
+
+        img = np.full((256, 256, 3), 128, dtype=np.uint8)
+        warnings = check_image_quality(img)
+        assert any("Blurry" in w for w in warnings)


### PR DESCRIPTION
## Summary
- Add `check_image_quality()` function that detects low resolution (< 128px), blur (Laplacian variance), and poor lighting (mean brightness)
- Called at the start of `generate()`, logs warnings and includes them in the result dict
- Non-blocking: warnings don't prevent processing
- Tests skip gracefully when torch is not installed

Closes #206