### PR TITLE
Enable attention slicing on CUDA and CPU for low-VRAM support

### DIFF
--- a/landmarkdiff/inference.py
+++ b/landmarkdiff/inference.py
@@ -383,8 +383,11 @@ class LandmarkDiffPipeline:
                 self._pipe.enable_model_cpu_offload()
             except Exception:
                 self._pipe = self._pipe.to(self.device)
+            # Attention slicing trades compute for VRAM on low-memory GPUs
+            self._pipe.enable_attention_slicing()
         else:
             self._pipe.enable_sequential_cpu_offload()
+            self._pipe.enable_attention_slicing()
         logger.info("Pipeline loaded on %s (%s)", self.device, self.dtype)
 
     @property


### PR DESCRIPTION
## Summary
- Enable `enable_attention_slicing()` for CUDA and CPU devices (was MPS-only)
- Trades compute time for reduced peak VRAM usage
- Allows inference on GPUs with less than 8GB VRAM

Closes #190