### PR TITLE
Add HEIC, WebP, and AVIF image format support

### DIFF
--- a/landmarkdiff/cli.py
+++ b/landmarkdiff/cli.py
@@ -24,9 +24,9 @@ def cmd_infer(args: argparse.Namespace) -> None:
 
     import cv2
 
-    from landmarkdiff.inference import LandmarkDiffPipeline
+    from landmarkdiff.inference import LandmarkDiffPipeline, load_image
 
-    image = cv2.imread(args.image)
+    image = load_image(args.image)
     if image is None:
         logger.error("Cannot read image: %s", args.image)
         sys.exit(1)
@@ -121,12 +121,11 @@ def cmd_config(args: argparse.Namespace) -> None:
 
 def cmd_validate(args: argparse.Namespace) -> None:
     """Run safety validation on an output image."""
-    import cv2
-
+    from landmarkdiff.inference import load_image
     from landmarkdiff.safety import SafetyValidator
 
-    input_img = cv2.imread(args.input)
-    output_img = cv2.imread(args.output_image)
+    input_img = load_image(args.input)
+    output_img = load_image(args.output_image)
 
     if input_img is None or output_img is None:
         logger.error("Cannot read input or output image.")

--- a/landmarkdiff/inference.py
+++ b/landmarkdiff/inference.py
@@ -54,6 +54,36 @@ def pil_to_numpy(img: Image.Image) -> np.ndarray:
     return arr
 
 
+# Extensions that cv2.imread handles natively
+_CV2_NATIVE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
+# Extensions that need Pillow fallback (HEIC, WebP, AVIF)
+_PILLOW_EXTS = {".heic", ".heif", ".webp", ".avif"}
+
+
+def load_image(path: str) -> np.ndarray | None:
+    """Load an image from disk, supporting HEIC, WebP, and AVIF via Pillow.
+
+    Falls back to Pillow for formats that OpenCV cannot read natively.
+    Returns BGR numpy array or None if the file cannot be loaded.
+    """
+    from pathlib import Path
+
+    ext = Path(path).suffix.lower()
+
+    if ext in _CV2_NATIVE_EXTS or ext not in _PILLOW_EXTS:
+        img = cv2.imread(path)
+        if img is not None:
+            return img
+
+    # Pillow fallback for HEIC/WebP/AVIF
+    try:
+        pil_img = Image.open(path).convert("RGB")
+        return np.array(pil_img)[:, :, ::-1].copy()  # RGB -> BGR
+    except Exception:
+        logger.warning("Could not load image: %s", path)
+        return None
+
+
 PROCEDURE_PROMPTS: dict[str, str] = {
     "rhinoplasty": (
         "clinical photograph, patient face, natural refined nose, smooth nasal bridge, "
@@ -745,7 +775,7 @@ def run_inference(
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
-    image = cv2.imread(image_path)
+    image = load_image(image_path)
     if image is None:
         logger.error("Could not load %s", image_path)
         sys.exit(1)


### PR DESCRIPTION
## Summary
- Adds `load_image()` utility with Pillow fallback for non-standard formats
- Supports HEIC/HEIF (iPhone), WebP, and AVIF in addition to JPEG/PNG/BMP/TIFF
- Updates CLI and inference entry points to use the new loader
- Closes #76

## Test plan
- [x] CLI tests pass (34/34)
- [ ] CI lint + test matrix