### PR TITLE
Add confidence-weighted landmark deformation

### DIFF
--- a/landmarkdiff/landmarks.py
+++ b/landmarkdiff/landmarks.py
@@ -219,6 +219,21 @@ class FaceLandmarks:
         return self.landmarks[indices]
 
     @property
+    def landmark_confidence(self) -> np.ndarray:
+        """Per-landmark confidence weights based on z-depth dispersion.
+
+        Landmarks with extreme z-values relative to the face center tend
+        to be less reliable (self-occlusion, profile views). Returns a
+        (478,) array in [0.5, 1.0] where 1.0 = high confidence.
+        """
+        z = self.landmarks[:, 2]
+        z_center = np.median(z)
+        z_dev = np.abs(z - z_center)
+        z_max = z_dev.max() if z_dev.max() > 0 else 1.0
+        # Map deviation [0, max] to confidence [1.0, 0.5]
+        return 1.0 - 0.5 * (z_dev / z_max)
+
+    @property
     def face_rotation(self) -> float:
         """Estimate in-plane face rotation in degrees from eye corners.
 

--- a/landmarkdiff/manipulation.py
+++ b/landmarkdiff/manipulation.py
@@ -368,7 +368,25 @@ def apply_procedure_preset(
     pixel_landmarks[:, 0] *= face.image_width
     pixel_landmarks[:, 1] *= face.image_height
 
-    pixel_landmarks = gaussian_rbf_deform_batch(pixel_landmarks, handles)
+    # Scale each handle's displacement by the confidence of its anchor
+    # landmark. Low-confidence landmarks (e.g., near face boundary on
+    # profile views) are deformed less aggressively.
+    conf = face.landmark_confidence
+    scaled_handles = []
+    for handle in handles:
+        c = float(conf[handle.landmark_index])
+        if c < 1.0:
+            scaled_handles.append(
+                DeformationHandle(
+                    landmark_index=handle.landmark_index,
+                    displacement=handle.displacement * c,
+                    influence_radius=handle.influence_radius,
+                )
+            )
+        else:
+            scaled_handles.append(handle)
+
+    pixel_landmarks = gaussian_rbf_deform_batch(pixel_landmarks, scaled_handles)
 
     # Convert back to normalized
     result = pixel_landmarks.copy()


### PR DESCRIPTION
## Summary
- Add `landmark_confidence` property to `FaceLandmarks` that estimates per-landmark reliability from z-depth dispersion
- Scale deformation handle displacements by confidence in `apply_procedure_preset`, reducing warp magnitude for unreliable landmarks (self-occluded, profile views)
- Confidence range [0.5, 1.0] where 1.0 = high confidence (near median z-depth)

## Test plan
- [x] 70/70 manipulation tests pass
- [x] ruff check + format clean
- [ ] CI passes (lint, type-check, test 3.10/3.11/3.12)

Closes #148