### PR TITLE
Add batch processing notebook

### DIFF
--- a/examples/batch_processing.ipynb
+++ b/examples/batch_processing.ipynb
@@ -1,0 +1,329 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Batch Processing with LandmarkDiff\n",
+    "\n",
+    "This notebook demonstrates how to process multiple face images in batch,\n",
+    "apply surgical procedure predictions, and collect results for analysis.\n",
+    "\n",
+    "**Requirements:**\n",
+    "- `pip install landmarkdiff`\n",
+    "- A directory of face images (JPG/PNG)\n",
+    "- For GPU inference: CUDA-capable GPU with PyTorch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import cv2\n",
+    "import numpy as np\n",
+    "from IPython.display import display, Image as IPImage\n",
+    "\n",
+    "from landmarkdiff.landmarks import extract_landmarks, load_image\n",
+    "from landmarkdiff.manipulation import apply_procedure_preset, PROCEDURE_LANDMARKS\n",
+    "from landmarkdiff.masking import generate_surgical_mask\n",
+    "from landmarkdiff.inference import mask_composite\n",
+    "from landmarkdiff.synthetic.tps_warp import warp_image_tps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Load images from a directory\n",
+    "\n",
+    "Set `INPUT_DIR` to a folder containing face images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "INPUT_DIR = Path(\"sample_faces\")  # Change to your image directory\n",
+    "OUTPUT_DIR = Path(\"batch_output\")\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "EXTENSIONS = {\".jpg\", \".jpeg\", \".png\", \".bmp\", \".webp\"}\n",
+    "image_paths = sorted(\n",
+    "    p for p in INPUT_DIR.iterdir()\n",
+    "    if p.suffix.lower() in EXTENSIONS\n",
+    ")\n",
+    "print(f\"Found {len(image_paths)} images\")\n",
+    "for p in image_paths[:5]:\n",
+    "    print(f\"  {p.name}\")\n",
+    "if len(image_paths) > 5:\n",
+    "    print(f\"  ... and {len(image_paths) - 5} more\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Extract landmarks from all images\n",
+    "\n",
+    "This step detects faces and extracts 478 MediaPipe landmarks per image.\n",
+    "Images where no face is detected are skipped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = []  # List of (path, image, landmarks)\n",
+    "skipped = []\n",
+    "\n",
+    "for path in image_paths:\n",
+    "    img = load_image(str(path))\n",
+    "    face = extract_landmarks(img)\n",
+    "    if face is None:\n",
+    "        skipped.append(path.name)\n",
+    "        continue\n",
+    "    results.append((path, img, face))\n",
+    "\n",
+    "print(f\"Extracted landmarks: {len(results)} / {len(image_paths)}\")\n",
+    "if skipped:\n",
+    "    print(f\"Skipped (no face detected): {skipped}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Batch process: apply procedure to all images\n",
+    "\n",
+    "Apply a single procedure at a fixed intensity using TPS mode (CPU, no GPU required)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROCEDURE = \"rhinoplasty\"\n",
+    "INTENSITY = 60.0\n",
+    "\n",
+    "predictions = []\n",
+    "\n",
+    "for path, img, face in results:\n",
+    "    # Apply deformation\n",
+    "    modified = apply_procedure_preset(face, PROCEDURE, INTENSITY)\n",
+    "    \n",
+    "    # Warp image using TPS (CPU-based, no diffusion model needed)\n",
+    "    warped = warp_image_tps(img, face, modified)\n",
+    "    \n",
+    "    # Generate mask and composite\n",
+    "    mask = generate_surgical_mask(face, PROCEDURE, img.shape[:2])\n",
+    "    composited = mask_composite(warped, img, mask)\n",
+    "    \n",
+    "    # Save result\n",
+    "    out_path = OUTPUT_DIR / f\"{path.stem}_{PROCEDURE}.png\"\n",
+    "    cv2.imwrite(str(out_path), composited)\n",
+    "    predictions.append((path.name, out_path, composited))\n",
+    "\n",
+    "print(f\"Processed {len(predictions)} images -> {OUTPUT_DIR}/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Multi-procedure batch\n",
+    "\n",
+    "Apply different procedures and intensities to each image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define procedure configurations per image or globally\n",
+    "procedure_configs = [\n",
+    "    {\"procedure\": \"rhinoplasty\", \"intensity\": 50.0},\n",
+    "    {\"procedure\": \"blepharoplasty\", \"intensity\": 40.0},\n",
+    "    {\"procedure\": \"rhytidectomy\", \"intensity\": 60.0},\n",
+    "]\n",
+    "\n",
+    "for path, img, face in results:\n",
+    "    for config in procedure_configs:\n",
+    "        proc = config[\"procedure\"]\n",
+    "        intensity = config[\"intensity\"]\n",
+    "        \n",
+    "        modified = apply_procedure_preset(face, proc, intensity)\n",
+    "        warped = warp_image_tps(img, face, modified)\n",
+    "        mask = generate_surgical_mask(face, proc, img.shape[:2])\n",
+    "        composited = mask_composite(warped, img, mask)\n",
+    "        \n",
+    "        out_path = OUTPUT_DIR / f\"{path.stem}_{proc}_i{int(intensity)}.png\"\n",
+    "        cv2.imwrite(str(out_path), composited)\n",
+    "\n",
+    "total = len(results) * len(procedure_configs)\n",
+    "print(f\"Generated {total} predictions ({len(results)} images x {len(procedure_configs)} procedures)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Intensity sweep\n",
+    "\n",
+    "Generate predictions at multiple intensity levels for a single image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if results:\n",
+    "    path, img, face = results[0]  # Use the first image\n",
+    "    proc = \"rhinoplasty\"\n",
+    "    intensities = [20, 40, 60, 80, 100]\n",
+    "    \n",
+    "    sweep_dir = OUTPUT_DIR / \"intensity_sweep\"\n",
+    "    sweep_dir.mkdir(exist_ok=True)\n",
+    "    \n",
+    "    for intensity in intensities:\n",
+    "        modified = apply_procedure_preset(face, proc, float(intensity))\n",
+    "        warped = warp_image_tps(img, face, modified)\n",
+    "        mask = generate_surgical_mask(face, proc, img.shape[:2])\n",
+    "        composited = mask_composite(warped, img, mask)\n",
+    "        \n",
+    "        out_path = sweep_dir / f\"{path.stem}_{proc}_i{intensity}.png\"\n",
+    "        cv2.imwrite(str(out_path), composited)\n",
+    "    \n",
+    "    print(f\"Intensity sweep saved to {sweep_dir}/\")\n",
+    "else:\n",
+    "    print(\"No images loaded -- set INPUT_DIR above\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Collect statistics\n",
+    "\n",
+    "Compute landmark displacement statistics across the batch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proc = \"rhinoplasty\"\n",
+    "intensity = 60.0\n",
+    "\n",
+    "displacements = []\n",
+    "for path, img, face in results:\n",
+    "    modified = apply_procedure_preset(face, proc, intensity)\n",
+    "    orig_px = face.pixel_coords[:, :2]\n",
+    "    mod_px = modified.pixel_coords[:, :2]\n",
+    "    disp = np.sqrt(np.sum((mod_px - orig_px) ** 2, axis=1))\n",
+    "    displacements.append(disp)\n",
+    "\n",
+    "if displacements:\n",
+    "    all_disp = np.stack(displacements)\n",
+    "    print(f\"Batch displacement statistics ({len(results)} images):\")\n",
+    "    print(f\"  Mean displacement: {all_disp.mean():.2f} px\")\n",
+    "    print(f\"  Max displacement:  {all_disp.max():.2f} px\")\n",
+    "    print(f\"  Std deviation:     {all_disp.std():.2f} px\")\n",
+    "    \n",
+    "    # Per-procedure-region stats\n",
+    "    proc_indices = PROCEDURE_LANDMARKS[proc]\n",
+    "    region_disp = all_disp[:, proc_indices]\n",
+    "    print(f\"  Region mean:       {region_disp.mean():.2f} px\")\n",
+    "    print(f\"  Region max:        {region_disp.max():.2f} px\")\n",
+    "else:\n",
+    "    print(\"No images loaded\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Export results as CSV\n",
+    "\n",
+    "Save per-image metadata and displacement statistics to a CSV file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "\n",
+    "csv_path = OUTPUT_DIR / \"batch_results.csv\"\n",
+    "with open(csv_path, \"w\", newline=\"\") as f:\n",
+    "    writer = csv.writer(f)\n",
+    "    writer.writerow([\"filename\", \"width\", \"height\", \"confidence\",\n",
+    "                     \"procedure\", \"intensity\", \"mean_displacement\", \"max_displacement\"])\n",
+    "    \n",
+    "    for (path, img, face), disp in zip(results, displacements):\n",
+    "        writer.writerow([\n",
+    "            path.name,\n",
+    "            face.image_width,\n",
+    "            face.image_height,\n",
+    "            f\"{face.confidence:.3f}\",\n",
+    "            proc,\n",
+    "            intensity,\n",
+    "            f\"{disp.mean():.2f}\",\n",
+    "            f\"{disp.max():.2f}\",\n",
+    "        ])\n",
+    "\n",
+    "print(f\"Results saved to {csv_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Available Procedures\n",
+    "\n",
+    "LandmarkDiff supports the following surgical procedure presets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Available procedures:\")\n",
+    "for proc in sorted(PROCEDURE_LANDMARKS.keys()):\n",
+    "    n_landmarks = len(PROCEDURE_LANDMARKS[proc])\n",
+    "    print(f\"  {proc:30s} ({n_landmarks} landmarks)\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- Add `examples/batch_processing.ipynb` with 7 sections:
  1. Load images from directory
  2. Extract landmarks from all images
  3. Single procedure batch processing (TPS mode)
  4. Multi-procedure batch (multiple configs per image)
  5. Intensity sweep (20-100 range)
  6. Batch displacement statistics
  7. CSV export of results

## Test plan
- [x] Notebook cells are syntactically valid Python
- [x] Imports match current API
- [x] Complements existing `batch_inference.py` script

Closes #233