### PR TITLE
Add pipeline profiler for stage-by-stage bottleneck analysis

### DIFF
--- a/landmarkdiff/benchmark.py
+++ b/landmarkdiff/benchmark.py
@@ -211,3 +211,153 @@ class Timer:
 
     def __exit__(self, *args: Any) -> None:
         self.end_time = time.perf_counter()
+
+
+# ---------------------------------------------------------------------------
+# Pipeline profiler
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StageProfile:
+    """Timing profile for a single pipeline stage."""
+
+    name: str
+    times_ms: list[float] = field(default_factory=list)
+
+    @property
+    def mean_ms(self) -> float:
+        return sum(self.times_ms) / len(self.times_ms) if self.times_ms else 0.0
+
+    @property
+    def min_ms(self) -> float:
+        return min(self.times_ms) if self.times_ms else 0.0
+
+    @property
+    def max_ms(self) -> float:
+        return max(self.times_ms) if self.times_ms else 0.0
+
+    @property
+    def total_ms(self) -> float:
+        return sum(self.times_ms)
+
+    @property
+    def count(self) -> int:
+        return len(self.times_ms)
+
+
+class PipelineProfiler:
+    """Profile each stage of the LandmarkDiff pipeline.
+
+    Collects per-stage wall-clock timings to identify bottlenecks
+    across landmark extraction, manipulation, masking, and inference.
+
+    Usage:
+        profiler = PipelineProfiler()
+        with profiler.stage("landmark_extraction"):
+            face = extract_landmarks(image)
+        with profiler.stage("manipulation"):
+            modified = apply_procedure_preset(face, "rhinoplasty")
+        print(profiler.summary())
+    """
+
+    def __init__(self) -> None:
+        self._stages: dict[str, StageProfile] = {}
+        self._order: list[str] = []
+
+    def stage(self, name: str) -> _StageTimer:
+        """Context manager that times a named pipeline stage."""
+        if name not in self._stages:
+            self._stages[name] = StageProfile(name=name)
+            self._order.append(name)
+        return _StageTimer(self._stages[name])
+
+    def record(self, name: str, elapsed_ms: float) -> None:
+        """Manually record a stage timing."""
+        if name not in self._stages:
+            self._stages[name] = StageProfile(name=name)
+            self._order.append(name)
+        self._stages[name].times_ms.append(elapsed_ms)
+
+    @property
+    def stages(self) -> list[StageProfile]:
+        return [self._stages[n] for n in self._order]
+
+    @property
+    def total_ms(self) -> float:
+        return sum(s.total_ms for s in self._stages.values())
+
+    def bottleneck(self) -> str | None:
+        """Name of the slowest stage by mean time."""
+        if not self._stages:
+            return None
+        return max(self._stages.values(), key=lambda s: s.mean_ms).name
+
+    def summary(self) -> str:
+        """Text summary of pipeline stage timings."""
+        if not self._stages:
+            return "No profile data."
+
+        total = self.total_ms
+        header = (
+            f"{'Stage':>25s} | {'Mean(ms)':>10s} | {'Min':>8s}"
+            f" | {'Max':>8s} | {'%':>6s} | {'N':>4s}"
+        )
+        lines = ["Pipeline Profile", header, "-" * len(header)]
+
+        for name in self._order:
+            s = self._stages[name]
+            pct = (s.total_ms / total * 100) if total > 0 else 0
+            lines.append(
+                f"{s.name:>25s} | "
+                f"{s.mean_ms:>10.1f} | "
+                f"{s.min_ms:>8.1f} | "
+                f"{s.max_ms:>8.1f} | "
+                f"{pct:>5.1f}% | "
+                f"{s.count:>4d}"
+            )
+
+        lines.append("-" * len(header))
+        lines.append(f"{'Total':>25s} | {total:>10.1f}")
+        bn = self.bottleneck()
+        if bn:
+            lines.append(f"Bottleneck: {bn}")
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Export profile data as a dictionary."""
+        return {
+            "stages": {
+                name: {
+                    "mean_ms": round(self._stages[name].mean_ms, 2),
+                    "min_ms": round(self._stages[name].min_ms, 2),
+                    "max_ms": round(self._stages[name].max_ms, 2),
+                    "total_ms": round(self._stages[name].total_ms, 2),
+                    "count": self._stages[name].count,
+                }
+                for name in self._order
+            },
+            "total_ms": round(self.total_ms, 2),
+            "bottleneck": self.bottleneck(),
+        }
+
+    def reset(self) -> None:
+        """Clear all recorded timings."""
+        self._stages.clear()
+        self._order.clear()
+
+
+class _StageTimer:
+    """Internal context manager for PipelineProfiler.stage()."""
+
+    def __init__(self, profile: StageProfile) -> None:
+        self._profile = profile
+        self._start: float = 0.0
+
+    def __enter__(self) -> _StageTimer:
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        elapsed = (time.perf_counter() - self._start) * 1000
+        self._profile.times_ms.append(elapsed)

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,126 @@
+"""Tests for pipeline profiling utilities."""
+
+from __future__ import annotations
+
+import time
+
+from landmarkdiff.benchmark import PipelineProfiler, StageProfile
+
+
+class TestStageProfile:
+    def test_empty_profile(self):
+        sp = StageProfile(name="test")
+        assert sp.mean_ms == 0.0
+        assert sp.min_ms == 0.0
+        assert sp.max_ms == 0.0
+        assert sp.count == 0
+
+    def test_single_timing(self):
+        sp = StageProfile(name="test", times_ms=[10.0])
+        assert sp.mean_ms == 10.0
+        assert sp.min_ms == 10.0
+        assert sp.max_ms == 10.0
+        assert sp.count == 1
+
+    def test_multiple_timings(self):
+        sp = StageProfile(name="test", times_ms=[10.0, 20.0, 30.0])
+        assert sp.mean_ms == 20.0
+        assert sp.min_ms == 10.0
+        assert sp.max_ms == 30.0
+        assert sp.total_ms == 60.0
+        assert sp.count == 3
+
+
+class TestPipelineProfiler:
+    def test_empty_profiler(self):
+        p = PipelineProfiler()
+        assert p.total_ms == 0.0
+        assert p.bottleneck() is None
+        assert p.stages == []
+
+    def test_stage_context_manager(self):
+        p = PipelineProfiler()
+        with p.stage("fast"):
+            time.sleep(0.001)
+        assert len(p.stages) == 1
+        assert p.stages[0].name == "fast"
+        assert p.stages[0].count == 1
+        assert p.stages[0].mean_ms > 0
+
+    def test_multiple_stages(self):
+        p = PipelineProfiler()
+        with p.stage("step_a"):
+            time.sleep(0.001)
+        with p.stage("step_b"):
+            time.sleep(0.001)
+        assert len(p.stages) == 2
+        assert p.stages[0].name == "step_a"
+        assert p.stages[1].name == "step_b"
+
+    def test_repeated_stage(self):
+        p = PipelineProfiler()
+        for _ in range(3):
+            with p.stage("repeated"):
+                time.sleep(0.001)
+        assert len(p.stages) == 1
+        assert p.stages[0].count == 3
+
+    def test_manual_record(self):
+        p = PipelineProfiler()
+        p.record("manual", 5.0)
+        p.record("manual", 15.0)
+        assert p.stages[0].mean_ms == 10.0
+        assert p.stages[0].count == 2
+
+    def test_bottleneck(self):
+        p = PipelineProfiler()
+        p.record("fast", 1.0)
+        p.record("slow", 100.0)
+        p.record("medium", 10.0)
+        assert p.bottleneck() == "slow"
+
+    def test_summary_format(self):
+        p = PipelineProfiler()
+        p.record("extraction", 50.0)
+        p.record("manipulation", 5.0)
+        p.record("masking", 8.0)
+        summary = p.summary()
+        assert "Pipeline Profile" in summary
+        assert "extraction" in summary
+        assert "Bottleneck: extraction" in summary
+
+    def test_to_dict(self):
+        p = PipelineProfiler()
+        p.record("step_a", 10.0)
+        p.record("step_b", 20.0)
+        d = p.to_dict()
+        assert "stages" in d
+        assert "step_a" in d["stages"]
+        assert "step_b" in d["stages"]
+        assert d["total_ms"] == 30.0
+        assert d["bottleneck"] == "step_b"
+        assert d["stages"]["step_a"]["mean_ms"] == 10.0
+
+    def test_reset(self):
+        p = PipelineProfiler()
+        p.record("step", 10.0)
+        assert len(p.stages) == 1
+        p.reset()
+        assert len(p.stages) == 0
+        assert p.total_ms == 0.0
+
+    def test_stage_order_preserved(self):
+        p = PipelineProfiler()
+        p.record("c", 1.0)
+        p.record("a", 2.0)
+        p.record("b", 3.0)
+        names = [s.name for s in p.stages]
+        assert names == ["c", "a", "b"]
+
+    def test_percentage_in_summary(self):
+        p = PipelineProfiler()
+        p.record("dominant", 90.0)
+        p.record("minor", 10.0)
+        summary = p.summary()
+        assert "90.0%" in summary
+        assert "10.0%" in summary


### PR DESCRIPTION
## Summary
- Add `PipelineProfiler` class with context manager and manual recording
- Per-stage timing with mean/min/max/percentage breakdown
- Automatic bottleneck identification
- Text summary and dict export for programmatic access

Closes #174

## Test plan
- [x] 14 tests covering all profiler functionality
- [x] Lint and format clean
- [ ] CI passes on all Python versions