### PR TITLE
Add mixed-precision inference utilities

### DIFF
--- a/landmarkdiff/inference.py
+++ b/landmarkdiff/inference.py
@@ -810,6 +810,77 @@ def run_inference(
     logger.info("Results saved to %s/", out)
 
 
+# ---------------------------------------------------------------------------
+# Mixed-precision inference utilities
+# ---------------------------------------------------------------------------
+
+
+def get_optimal_dtype(device: torch.device | None = None) -> torch.dtype:
+    """Select the optimal dtype for a device.
+
+    - CUDA with Tensor Cores (compute >= 7.0): float16
+    - CUDA without Tensor Cores: float32
+    - MPS (Apple Silicon): float32 (float16 is unreliable on MPS)
+    - CPU: float32
+
+    Returns:
+        torch.dtype suitable for the target device.
+    """
+    if device is None:
+        device = get_device()
+
+    if device.type == "cuda":
+        cap = torch.cuda.get_device_capability(device)
+        if cap[0] >= 7:
+            return torch.float16
+        return torch.float32
+    return torch.float32
+
+
+def estimate_vram_usage(
+    resolution: int = 512,
+    dtype: torch.dtype = torch.float16,
+    num_inference_steps: int = 20,
+    mode: str = "controlnet",
+) -> dict[str, float]:
+    """Estimate VRAM usage for a given inference configuration.
+
+    Returns a dict with estimated VRAM in GB for each component.
+    These are rough estimates based on SD1.5 + ControlNet architecture.
+    """
+    # Base model sizes in GB (SD1.5)
+    unet_params = 860e6  # ~860M parameters
+    controlnet_params = 361e6  # ~361M parameters
+    vae_params = 83e6  # ~83M parameters
+    text_encoder_params = 123e6  # ~123M parameters
+
+    bytes_per_param = 2 if dtype == torch.float16 else 4
+
+    unet_gb = unet_params * bytes_per_param / 1e9
+    cn_gb = controlnet_params * bytes_per_param / 1e9 if "controlnet" in mode else 0
+    vae_gb = vae_params * 4 / 1e9  # VAE always FP32
+    text_gb = text_encoder_params * bytes_per_param / 1e9
+
+    # Latent space activations (resolution/8 due to VAE downscale)
+    latent_size = resolution // 8
+    latent_channels = 4
+    latent_bytes = latent_size * latent_size * latent_channels * bytes_per_param
+    activations_gb = latent_bytes * num_inference_steps * 2 / 1e9  # rough
+
+    total = unet_gb + cn_gb + vae_gb + text_gb + activations_gb
+
+    return {
+        "unet_gb": round(unet_gb, 2),
+        "controlnet_gb": round(cn_gb, 2),
+        "vae_gb": round(vae_gb, 2),
+        "text_encoder_gb": round(text_gb, 2),
+        "activations_gb": round(activations_gb, 2),
+        "total_gb": round(total, 2),
+        "dtype": str(dtype),
+        "resolution": resolution,
+    }
+
+
 if __name__ == "__main__":
     import argparse
 

--- a/tests/test_fp16_inference.py
+++ b/tests/test_fp16_inference.py
@@ -1,0 +1,78 @@
+"""Tests for mixed-precision inference utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from landmarkdiff.inference import estimate_vram_usage, get_optimal_dtype  # noqa: E402
+
+
+class TestGetOptimalDtype:
+    def test_cpu_returns_float32(self):
+        assert get_optimal_dtype(torch.device("cpu")) == torch.float32
+
+    def test_returns_a_torch_dtype(self):
+        result = get_optimal_dtype(torch.device("cpu"))
+        assert isinstance(result, torch.dtype)
+
+    def test_none_device_does_not_raise(self):
+        # Should auto-detect device without error
+        result = get_optimal_dtype(None)
+        assert result in (torch.float16, torch.float32)
+
+    def test_default_returns_valid_dtype(self):
+        result = get_optimal_dtype()
+        assert result in (torch.float16, torch.float32)
+
+
+class TestEstimateVramUsage:
+    def test_returns_dict(self):
+        result = estimate_vram_usage()
+        assert isinstance(result, dict)
+        assert "total_gb" in result
+        assert "unet_gb" in result
+
+    def test_total_positive(self):
+        result = estimate_vram_usage()
+        assert result["total_gb"] > 0
+
+    def test_fp16_smaller_than_fp32(self):
+        fp16 = estimate_vram_usage(dtype=torch.float16)
+        fp32 = estimate_vram_usage(dtype=torch.float32)
+        assert fp16["total_gb"] < fp32["total_gb"]
+
+    def test_controlnet_larger_than_img2img(self):
+        cn = estimate_vram_usage(mode="controlnet")
+        img = estimate_vram_usage(mode="img2img")
+        assert cn["total_gb"] > img["total_gb"]
+
+    def test_higher_resolution_uses_more_vram(self):
+        low = estimate_vram_usage(resolution=256)
+        high = estimate_vram_usage(resolution=1024)
+        assert high["total_gb"] > low["total_gb"]
+
+    def test_includes_resolution(self):
+        result = estimate_vram_usage(resolution=768)
+        assert result["resolution"] == 768
+
+    def test_includes_dtype_string(self):
+        result = estimate_vram_usage(dtype=torch.float16)
+        assert "float16" in result["dtype"]
+
+    def test_controlnet_gb_zero_for_non_controlnet(self):
+        result = estimate_vram_usage(mode="img2img")
+        assert result["controlnet_gb"] == 0
+
+    def test_vae_always_fp32(self):
+        fp16 = estimate_vram_usage(dtype=torch.float16)
+        fp32 = estimate_vram_usage(dtype=torch.float32)
+        # VAE size should be the same regardless of dtype
+        assert fp16["vae_gb"] == fp32["vae_gb"]
+
+    def test_all_components_nonnegative(self):
+        result = estimate_vram_usage()
+        for key, val in result.items():
+            if isinstance(val, float):
+                assert val >= 0, f"{key} is negative: {val}"


### PR DESCRIPTION
## Summary
- Add `get_optimal_dtype()` for automatic dtype selection based on GPU compute capability
- Add `estimate_vram_usage()` for predicting memory requirements across configurations
- VAE always kept at FP32 for color accuracy; UNet/ControlNet use FP16 on Tensor Core GPUs

Closes #186

## Test plan
- [x] 14 tests (skipped when torch not available in CI)
- [x] Lint and format clean
- [ ] CI passes on all Python versions