### PR TITLE
Add callback-based progress reporter for pipeline stages

### DIFF
--- a/landmarkdiff/benchmark.py
+++ b/landmarkdiff/benchmark.py
@@ -361,3 +361,108 @@ class _StageTimer:
     def __exit__(self, *args: Any) -> None:
         elapsed = (time.perf_counter() - self._start) * 1000
         self._profile.times_ms.append(elapsed)
+
+
+# ---------------------------------------------------------------------------
+# Progress reporting
+# ---------------------------------------------------------------------------
+
+# Standard pipeline stages with human-readable descriptions and
+# approximate percentage of total runtime.
+PIPELINE_STAGES: list[tuple[str, str, int]] = [
+    ("loading", "Loading model weights", 5),
+    ("landmark_extraction", "Extracting facial landmarks", 10),
+    ("manipulation", "Applying surgical deformation", 15),
+    ("conditioning", "Generating conditioning image", 20),
+    ("masking", "Computing surgical mask", 25),
+    ("tps_warp", "Warping image (TPS)", 35),
+    ("inference", "Running diffusion model", 70),
+    ("postprocessing", "Post-processing output", 90),
+    ("compositing", "Blending result", 95),
+    ("complete", "Done", 100),
+]
+
+_STAGE_INDEX = {name: i for i, (name, _, _) in enumerate(PIPELINE_STAGES)}
+
+
+class ProgressReporter:
+    """Callback-based progress reporter for the LandmarkDiff pipeline.
+
+    Provides stage-by-stage progress updates with human-readable
+    descriptions and percentage estimates.  Accepts a callback function
+    that receives (stage_name, description, percent) on each update.
+
+    Usage:
+        def on_progress(stage, desc, pct):
+            print(f"[{pct}%] {desc}")
+
+        reporter = ProgressReporter(callback=on_progress)
+        reporter.update("landmark_extraction")
+        reporter.update("manipulation")
+        # ...
+        reporter.update("complete")
+
+    For Gradio integration:
+        reporter = ProgressReporter(callback=gr.Progress())
+    """
+
+    def __init__(
+        self,
+        callback: Any | None = None,
+    ) -> None:
+        self._callback = callback
+        self._current_stage: str = ""
+        self._start_time: float = 0.0
+        self._stage_times: dict[str, float] = {}
+
+    def update(self, stage: str, description: str | None = None) -> None:
+        """Report progress for a named stage.
+
+        Args:
+            stage: Stage identifier (e.g. "landmark_extraction").
+                   Unknown stages are accepted with 0% progress.
+            description: Override the default stage description.
+        """
+        now = time.perf_counter()
+        if self._start_time == 0:
+            self._start_time = now
+
+        # Record timing for previous stage
+        if self._current_stage:
+            elapsed = (now - self._stage_start) * 1000
+            self._stage_times[self._current_stage] = elapsed
+
+        self._current_stage = stage
+        self._stage_start = now
+
+        # Look up stage info
+        idx = _STAGE_INDEX.get(stage)
+        if idx is not None:
+            _, default_desc, pct = PIPELINE_STAGES[idx]
+        else:
+            default_desc = stage.replace("_", " ").title()
+            pct = 0
+
+        desc = description or default_desc
+
+        if self._callback is not None:
+            try:
+                self._callback(stage, desc, pct)
+            except TypeError:
+                # Gradio Progress() takes (fraction, desc) instead
+                import contextlib
+
+                with contextlib.suppress(Exception):
+                    self._callback(pct / 100.0, desc=desc)
+
+    @property
+    def elapsed_ms(self) -> float:
+        """Total elapsed time since first update."""
+        if self._start_time == 0:
+            return 0.0
+        return (time.perf_counter() - self._start_time) * 1000
+
+    @property
+    def stage_times(self) -> dict[str, float]:
+        """Per-stage timing in milliseconds."""
+        return dict(self._stage_times)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,111 @@
+"""Tests for progress reporting utilities."""
+
+from __future__ import annotations
+
+import time
+
+from landmarkdiff.benchmark import PIPELINE_STAGES, ProgressReporter
+
+
+class TestPipelineStages:
+    def test_stages_defined(self):
+        assert len(PIPELINE_STAGES) >= 5
+
+    def test_stages_have_three_elements(self):
+        for stage in PIPELINE_STAGES:
+            assert len(stage) == 3
+            name, desc, pct = stage
+            assert isinstance(name, str)
+            assert isinstance(desc, str)
+            assert isinstance(pct, int)
+
+    def test_percentages_monotonic(self):
+        pcts = [pct for _, _, pct in PIPELINE_STAGES]
+        for i in range(1, len(pcts)):
+            assert pcts[i] >= pcts[i - 1]
+
+    def test_starts_above_zero(self):
+        assert PIPELINE_STAGES[0][2] > 0
+
+    def test_ends_at_100(self):
+        assert PIPELINE_STAGES[-1][2] == 100
+
+
+class TestProgressReporter:
+    def test_no_callback(self):
+        reporter = ProgressReporter()
+        reporter.update("landmark_extraction")
+        reporter.update("complete")
+        assert reporter.elapsed_ms > 0
+
+    def test_callback_called(self):
+        calls = []
+        reporter = ProgressReporter(callback=lambda s, d, p: calls.append((s, d, p)))
+        reporter.update("landmark_extraction")
+        reporter.update("manipulation")
+        assert len(calls) == 2
+        assert calls[0][0] == "landmark_extraction"
+        assert calls[1][0] == "manipulation"
+
+    def test_percentage_reported(self):
+        calls = []
+        reporter = ProgressReporter(callback=lambda s, d, p: calls.append(p))
+        reporter.update("landmark_extraction")
+        reporter.update("inference")
+        reporter.update("complete")
+        assert calls[0] == 10  # landmark_extraction
+        assert calls[1] == 70  # inference
+        assert calls[2] == 100  # complete
+
+    def test_custom_description(self):
+        calls = []
+        reporter = ProgressReporter(callback=lambda s, d, p: calls.append(d))
+        reporter.update("inference", description="Running custom model")
+        assert calls[0] == "Running custom model"
+
+    def test_unknown_stage_accepted(self):
+        calls = []
+        reporter = ProgressReporter(callback=lambda s, d, p: calls.append((s, p)))
+        reporter.update("custom_stage")
+        assert calls[0] == ("custom_stage", 0)
+
+    def test_elapsed_ms(self):
+        reporter = ProgressReporter()
+        reporter.update("landmark_extraction")
+        time.sleep(0.01)
+        reporter.update("complete")
+        assert reporter.elapsed_ms > 5
+
+    def test_stage_times(self):
+        reporter = ProgressReporter()
+        reporter.update("landmark_extraction")
+        time.sleep(0.01)
+        reporter.update("manipulation")
+        time.sleep(0.01)
+        reporter.update("complete")
+        times = reporter.stage_times
+        assert "landmark_extraction" in times
+        assert "manipulation" in times
+        assert times["landmark_extraction"] > 0
+
+    def test_gradio_style_callback(self):
+        """Gradio Progress() takes (fraction, desc=...) instead of (name, desc, pct)."""
+        calls = []
+
+        def gradio_like(fraction, desc=""):
+            calls.append((fraction, desc))
+
+        # Simulate TypeError on first call format, fallback to gradio style
+        reporter = ProgressReporter(callback=gradio_like)
+        reporter.update("landmark_extraction")
+        # Should have called with fraction format
+        assert len(calls) == 1
+
+    def test_no_callback_does_not_error(self):
+        reporter = ProgressReporter(callback=None)
+        reporter.update("landmark_extraction")
+        reporter.update("complete")
+
+    def test_initial_elapsed_is_zero(self):
+        reporter = ProgressReporter()
+        assert reporter.elapsed_ms == 0.0


### PR DESCRIPTION
## Summary
- Add `ProgressReporter` with callback-based stage progress updates
- Define 10 standard pipeline stages with descriptions and percentage estimates
- Support both standard 3-arg callbacks and Gradio-style `(fraction, desc=)` format
- Track per-stage timing for performance monitoring

Closes #205

## Test plan
- [x] 15 tests covering stage definitions, callbacks, timing, and edge cases
- [x] Lint clean
- [ ] CI passes