### PR TITLE
Add async Python client with concurrent batch support

### DIFF
--- a/landmarkdiff/api_client_async.py
+++ b/landmarkdiff/api_client_async.py
@@ -1,0 +1,264 @@
+"""Async Python client for the LandmarkDiff REST API.
+
+Provides an asyncio-compatible interface using aiohttp for non-blocking
+interaction with the FastAPI server.
+
+Usage:
+    import asyncio
+    from landmarkdiff.api_client_async import AsyncLandmarkDiffClient
+
+    async def main():
+        async with AsyncLandmarkDiffClient("http://localhost:8000") as client:
+            health = await client.health()
+            result = await client.predict("patient.png", procedure="rhinoplasty")
+            result.save("output.png")
+
+    asyncio.run(main())
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+
+from landmarkdiff.api_client import LandmarkDiffAPIError, PredictionResult
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncLandmarkDiffClient:
+    """Async client for the LandmarkDiff REST API.
+
+    Uses aiohttp for non-blocking HTTP requests. Supports context
+    manager usage and concurrent batch predictions.
+
+    Args:
+        base_url: Server URL (e.g. "http://localhost:8000").
+        timeout: Request timeout in seconds.
+        max_concurrent: Maximum concurrent requests for batch operations.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8000",
+        timeout: float = 60.0,
+        max_concurrent: int = 4,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.max_concurrent = max_concurrent
+        self._session: Any = None
+
+    async def _get_session(self) -> Any:
+        """Lazy-initialize aiohttp session."""
+        if self._session is None or self._session.closed:
+            try:
+                import aiohttp
+            except ImportError:
+                raise ImportError(
+                    "aiohttp required for async client. Install with: pip install aiohttp"
+                ) from None
+            timeout = aiohttp.ClientTimeout(total=self.timeout)
+            self._session = aiohttp.ClientSession(timeout=timeout)
+        return self._session
+
+    @staticmethod
+    def _read_image(image_path: str | Path) -> bytes:
+        """Read image file as bytes."""
+        path = Path(image_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Image not found: {path}")
+        return path.read_bytes()
+
+    @staticmethod
+    def _decode_base64_image(b64_string: str) -> np.ndarray:
+        """Decode a base64-encoded image to numpy array."""
+        img_bytes = base64.b64decode(b64_string)
+        arr = np.frombuffer(img_bytes, np.uint8)
+        img = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+        if img is None:
+            raise ValueError("Failed to decode base64 image")
+        return img
+
+    async def _handle_response(self, resp: Any) -> dict[str, Any]:
+        """Check response status and return JSON."""
+        if resp.status >= 400:
+            text = await resp.text()
+            raise LandmarkDiffAPIError(f"Server returned {resp.status}: {text[:200]}")
+        return await resp.json()
+
+    # ------------------------------------------------------------------
+    # API methods
+    # ------------------------------------------------------------------
+
+    async def health(self) -> dict[str, Any]:
+        """Check server health.
+
+        Returns:
+            Dict with status and version info.
+        """
+        session = await self._get_session()
+        try:
+            async with session.get(f"{self.base_url}/health") as resp:
+                return await self._handle_response(resp)
+        except LandmarkDiffAPIError:
+            raise
+        except Exception as e:
+            raise LandmarkDiffAPIError(
+                f"Cannot connect to server at {self.base_url}: {e}"
+            ) from None
+
+    async def procedures(self) -> list[str]:
+        """List available surgical procedures.
+
+        Returns:
+            List of procedure names.
+        """
+        session = await self._get_session()
+        try:
+            async with session.get(f"{self.base_url}/procedures") as resp:
+                data = await self._handle_response(resp)
+                return data.get("procedures", [])
+        except LandmarkDiffAPIError:
+            raise
+        except Exception as e:
+            raise LandmarkDiffAPIError(
+                f"Cannot connect to server at {self.base_url}: {e}"
+            ) from None
+
+    async def predict(
+        self,
+        image_path: str | Path,
+        procedure: str = "rhinoplasty",
+        intensity: float = 65.0,
+        seed: int = 42,
+    ) -> PredictionResult:
+        """Run surgical outcome prediction.
+
+        Args:
+            image_path: Path to input face image.
+            procedure: Surgical procedure type.
+            intensity: Intensity of the modification (0-100).
+            seed: Random seed for reproducibility.
+
+        Returns:
+            PredictionResult with output image and metadata.
+        """
+        import aiohttp
+
+        session = await self._get_session()
+        image_bytes = self._read_image(image_path)
+
+        data = aiohttp.FormData()
+        data.add_field("image", image_bytes, filename="image.png", content_type="image/png")
+        data.add_field("procedure", procedure)
+        data.add_field("intensity", str(intensity))
+        data.add_field("seed", str(seed))
+
+        try:
+            async with session.post(f"{self.base_url}/predict", data=data) as resp:
+                result = await self._handle_response(resp)
+
+                output_img = self._decode_base64_image(result["output_image"])
+
+                return PredictionResult(
+                    output_image=output_img,
+                    procedure=procedure,
+                    intensity=intensity,
+                    confidence=result.get("confidence", 0.0),
+                    metrics=result.get("metrics", {}),
+                    metadata=result.get("metadata", {}),
+                )
+        except LandmarkDiffAPIError:
+            raise
+        except Exception as e:
+            raise LandmarkDiffAPIError(f"Prediction failed: {e}") from None
+
+    async def analyze(self, image_path: str | Path) -> dict[str, Any]:
+        """Analyze a face image without generating a prediction.
+
+        Args:
+            image_path: Path to input face image.
+
+        Returns:
+            Dict with analysis results.
+        """
+        import aiohttp
+
+        session = await self._get_session()
+        image_bytes = self._read_image(image_path)
+
+        data = aiohttp.FormData()
+        data.add_field("image", image_bytes, filename="image.png", content_type="image/png")
+
+        try:
+            async with session.post(f"{self.base_url}/analyze", data=data) as resp:
+                return await self._handle_response(resp)
+        except LandmarkDiffAPIError:
+            raise
+        except Exception as e:
+            raise LandmarkDiffAPIError(f"Analysis failed: {e}") from None
+
+    async def batch_predict(
+        self,
+        image_paths: list[str | Path],
+        procedure: str = "rhinoplasty",
+        intensity: float = 65.0,
+        seed: int = 42,
+    ) -> list[PredictionResult]:
+        """Run concurrent batch prediction on multiple images.
+
+        Uses a semaphore to limit concurrent requests to max_concurrent.
+
+        Args:
+            image_paths: List of image file paths.
+            procedure: Procedure to apply to all images.
+            intensity: Intensity for all images.
+            seed: Base random seed.
+
+        Returns:
+            List of PredictionResult objects in the same order as inputs.
+        """
+        sem = asyncio.Semaphore(self.max_concurrent)
+
+        async def _predict_one(path: str | Path, idx: int) -> PredictionResult:
+            async with sem:
+                try:
+                    return await self.predict(
+                        path,
+                        procedure=procedure,
+                        intensity=intensity,
+                        seed=seed + idx,
+                    )
+                except Exception as e:
+                    logger.warning("Batch prediction failed for %s: %s", path, e)
+                    return PredictionResult(
+                        output_image=np.zeros((512, 512, 3), dtype=np.uint8),
+                        procedure=procedure,
+                        intensity=intensity,
+                        metadata={"error": str(e), "path": str(path)},
+                    )
+
+        tasks = [_predict_one(p, i) for i, p in enumerate(image_paths)]
+        return list(await asyncio.gather(*tasks))
+
+    async def close(self) -> None:
+        """Close the HTTP session."""
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    async def __aenter__(self) -> AsyncLandmarkDiffClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()
+
+    def __repr__(self) -> str:
+        return f"AsyncLandmarkDiffClient(base_url='{self.base_url}')"

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,242 @@
+"""Tests for the async LandmarkDiff API client."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from landmarkdiff.api_client import LandmarkDiffAPIError, PredictionResult
+from landmarkdiff.api_client_async import AsyncLandmarkDiffClient
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestAsyncClientInit:
+    def test_default_url(self):
+        client = AsyncLandmarkDiffClient()
+        assert client.base_url == "http://localhost:8000"
+
+    def test_custom_url_strips_trailing_slash(self):
+        client = AsyncLandmarkDiffClient("http://example.com:9000/")
+        assert client.base_url == "http://example.com:9000"
+
+    def test_default_timeout(self):
+        client = AsyncLandmarkDiffClient()
+        assert client.timeout == 60.0
+
+    def test_custom_timeout(self):
+        client = AsyncLandmarkDiffClient(timeout=30.0)
+        assert client.timeout == 30.0
+
+    def test_max_concurrent(self):
+        client = AsyncLandmarkDiffClient(max_concurrent=8)
+        assert client.max_concurrent == 8
+
+    def test_repr(self):
+        client = AsyncLandmarkDiffClient("http://test:8000")
+        assert "http://test:8000" in repr(client)
+
+
+class TestAsyncClientImageIO:
+    def test_read_image_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            AsyncLandmarkDiffClient._read_image("/nonexistent/image.png")
+
+    def test_read_image_from_file(self, tmp_path):
+        img_path = tmp_path / "test.png"
+        img_path.write_bytes(b"fake_image_data")
+        data = AsyncLandmarkDiffClient._read_image(img_path)
+        assert data == b"fake_image_data"
+
+    def test_decode_base64_invalid(self):
+        with pytest.raises(ValueError, match="Failed to decode"):
+            AsyncLandmarkDiffClient._decode_base64_image("aW52YWxpZA==")
+
+
+class TestAsyncClientSession:
+    def test_requires_aiohttp(self):
+        client = AsyncLandmarkDiffClient()
+        with (
+            patch.dict("sys.modules", {"aiohttp": None}),
+            pytest.raises(ImportError, match="aiohttp"),
+        ):
+            _run(client._get_session())
+
+    def test_close_noop_when_no_session(self):
+        client = AsyncLandmarkDiffClient()
+        _run(client.close())  # should not raise
+
+    def test_context_manager(self):
+        mock_session = AsyncMock()
+        mock_session.closed = False
+
+        async def _test():
+            with patch.object(
+                AsyncLandmarkDiffClient,
+                "_get_session",
+                return_value=mock_session,
+            ):
+                async with AsyncLandmarkDiffClient() as client:
+                    client._session = mock_session
+                mock_session.close.assert_called_once()
+
+        _run(_test())
+
+
+class TestAsyncClientHealth:
+    def test_health_returns_dict(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"status": "ok", "version": "0.2.0"})
+
+        mock_session = AsyncMock()
+        mock_session.closed = False
+        mock_session.get = MagicMock(return_value=_AsyncContext(mock_resp))
+
+        async def _test():
+            client = AsyncLandmarkDiffClient()
+            client._session = mock_session
+            result = await client.health()
+            assert result["status"] == "ok"
+
+        _run(_test())
+
+    def test_health_error(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 500
+        mock_resp.text = AsyncMock(return_value="Internal Server Error")
+
+        mock_session = AsyncMock()
+        mock_session.closed = False
+        mock_session.get = MagicMock(return_value=_AsyncContext(mock_resp))
+
+        async def _test():
+            client = AsyncLandmarkDiffClient()
+            client._session = mock_session
+            with pytest.raises(LandmarkDiffAPIError, match="500"):
+                await client.health()
+
+        _run(_test())
+
+
+class TestAsyncClientProcedures:
+    def test_procedures_returns_list(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"procedures": ["rhinoplasty", "blepharoplasty"]})
+
+        mock_session = AsyncMock()
+        mock_session.closed = False
+        mock_session.get = MagicMock(return_value=_AsyncContext(mock_resp))
+
+        async def _test():
+            client = AsyncLandmarkDiffClient()
+            client._session = mock_session
+            result = await client.procedures()
+            assert "rhinoplasty" in result
+            assert len(result) == 2
+
+        _run(_test())
+
+
+class TestAsyncClientBatch:
+    def test_batch_respects_max_concurrent(self):
+        """Verify semaphore limits concurrent requests."""
+
+        async def _test():
+            client = AsyncLandmarkDiffClient(max_concurrent=2)
+            active = 0
+            max_active = 0
+
+            async def mock_predict(path, **kwargs):
+                nonlocal active, max_active
+                active += 1
+                max_active = max(max_active, active)
+                await asyncio.sleep(0.01)
+                active -= 1
+                return PredictionResult(
+                    output_image=np.zeros((64, 64, 3), dtype=np.uint8),
+                    procedure="rhinoplasty",
+                    intensity=65.0,
+                )
+
+            client.predict = mock_predict
+            paths = [f"/fake/img_{i}.png" for i in range(6)]
+            results = await client.batch_predict(paths)
+            assert len(results) == 6
+            assert max_active <= 2
+
+        _run(_test())
+
+    def test_batch_preserves_order(self):
+        """Results should match input order."""
+
+        async def _test():
+            client = AsyncLandmarkDiffClient(max_concurrent=2)
+
+            async def mock_predict(path, **kwargs):
+                idx = int(str(path).split("_")[1].split(".")[0])
+                await asyncio.sleep(0.01 * (5 - idx))
+                return PredictionResult(
+                    output_image=np.full((64, 64, 3), idx, dtype=np.uint8),
+                    procedure="rhinoplasty",
+                    intensity=65.0,
+                    metadata={"index": idx},
+                )
+
+            client.predict = mock_predict
+            paths = [f"/fake/img_{i}.png" for i in range(5)]
+            results = await client.batch_predict(paths)
+            for i, r in enumerate(results):
+                assert r.metadata["index"] == i
+
+        _run(_test())
+
+    def test_batch_handles_individual_failures(self):
+        """Failed predictions should not block others."""
+
+        async def _test():
+            client = AsyncLandmarkDiffClient(max_concurrent=4)
+
+            async def mock_predict(path, **kwargs):
+                if "fail" in str(path):
+                    raise LandmarkDiffAPIError("Server error")
+                return PredictionResult(
+                    output_image=np.zeros((64, 64, 3), dtype=np.uint8),
+                    procedure="rhinoplasty",
+                    intensity=65.0,
+                )
+
+            client.predict = mock_predict
+            paths = ["/fake/ok.png", "/fake/fail.png", "/fake/also_ok.png"]
+            results = await client.batch_predict(paths)
+            assert len(results) == 3
+            assert "error" not in results[0].metadata
+            assert "error" in results[1].metadata
+            assert "error" not in results[2].metadata
+
+        _run(_test())
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+class _AsyncContext:
+    """Wrap an async mock to work as an async context manager."""
+
+    def __init__(self, resp: AsyncMock) -> None:
+        self.resp = resp
+
+    async def __aenter__(self) -> AsyncMock:
+        return self.resp
+
+    async def __aexit__(self, *args: object) -> None:
+        pass


### PR DESCRIPTION
## Summary
- Adds `AsyncLandmarkDiffClient` in `landmarkdiff/api_client_async.py` using aiohttp
- Supports all sync client operations: health, procedures, predict, analyze, batch_predict
- Batch predictions run concurrently with configurable semaphore (default 4)
- Reuses `PredictionResult` and `LandmarkDiffAPIError` from sync client
- 18 tests covering init, session management, health/procedures calls, and batch behavior

Closes #218

## Test plan
- [x] All 18 tests pass locally
- [ ] CI lint passes
- [ ] CI type-check passes
- [ ] CI tests pass on 3.10/3.11/3.12