### PR TITLE
Add webhook notifications with retry and HMAC signing

### DIFF
--- a/landmarkdiff/webhooks.py
+++ b/landmarkdiff/webhooks.py
@@ -1,0 +1,235 @@
+"""Webhook notification system for batch and pipeline events.
+
+Sends HTTP POST callbacks when predictions complete, fail, or when
+batch jobs finish. Supports retry with exponential backoff and
+optional HMAC-SHA256 signature verification.
+
+Usage:
+    from landmarkdiff.webhooks import WebhookNotifier
+
+    notifier = WebhookNotifier("https://example.com/webhook")
+    notifier.send("prediction.complete", {
+        "image_id": "patient_001",
+        "procedure": "rhinoplasty",
+        "status": "success",
+    })
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Recognized event types
+EVENT_TYPES = frozenset(
+    {
+        "prediction.started",
+        "prediction.complete",
+        "prediction.failed",
+        "batch.started",
+        "batch.progress",
+        "batch.complete",
+        "batch.failed",
+        "analysis.complete",
+        "health.degraded",
+    }
+)
+
+_DEFAULT_MAX_RETRIES = 3
+_DEFAULT_TIMEOUT = 10.0
+
+
+@dataclass
+class WebhookPayload:
+    """Structured webhook payload."""
+
+    event: str
+    data: dict[str, Any]
+    webhook_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event": self.event,
+            "data": self.data,
+            "webhook_id": self.webhook_id,
+            "timestamp": self.timestamp,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), default=str)
+
+
+@dataclass
+class WebhookDelivery:
+    """Record of a webhook delivery attempt."""
+
+    payload: WebhookPayload
+    status_code: int = 0
+    success: bool = False
+    attempts: int = 0
+    error: str = ""
+    duration_ms: float = 0.0
+
+
+class WebhookNotifier:
+    """Send webhook notifications with retry and optional signing.
+
+    Args:
+        url: Webhook endpoint URL.
+        secret: Optional HMAC-SHA256 signing secret.
+        max_retries: Maximum delivery attempts (default 3).
+        timeout: HTTP timeout in seconds (default 10).
+        headers: Extra HTTP headers to include.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        secret: str | None = None,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        timeout: float = _DEFAULT_TIMEOUT,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.url = url
+        self.secret = secret
+        self.max_retries = max_retries
+        self.timeout = timeout
+        self.headers = headers or {}
+        self._deliveries: list[WebhookDelivery] = []
+
+    def sign(self, body: str) -> str:
+        """Compute HMAC-SHA256 signature for a payload body.
+
+        Args:
+            body: JSON string to sign.
+
+        Returns:
+            Hex-encoded HMAC-SHA256 signature.
+
+        Raises:
+            ValueError: If no secret is configured.
+        """
+        if not self.secret:
+            raise ValueError("No signing secret configured")
+        return hmac.new(self.secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+
+    def verify(self, body: str, signature: str) -> bool:
+        """Verify an HMAC-SHA256 signature.
+
+        Args:
+            body: JSON string that was signed.
+            signature: Hex-encoded signature to verify.
+
+        Returns:
+            True if signature matches.
+        """
+        if not self.secret:
+            return False
+        expected = self.sign(body)
+        return hmac.compare_digest(expected, signature)
+
+    def send(
+        self,
+        event: str,
+        data: dict[str, Any] | None = None,
+    ) -> WebhookDelivery:
+        """Send a webhook notification.
+
+        Retries with exponential backoff on failure (1s, 2s, 4s, ...).
+
+        Args:
+            event: Event type (e.g. "prediction.complete").
+            data: Event-specific data payload.
+
+        Returns:
+            WebhookDelivery with status and attempt details.
+        """
+        try:
+            import requests
+        except ImportError:
+            raise ImportError(
+                "requests required for webhooks. Install with: pip install requests"
+            ) from None
+
+        payload = WebhookPayload(event=event, data=data or {})
+        body = payload.to_json()
+
+        request_headers = {
+            "Content-Type": "application/json",
+            "X-Webhook-Event": event,
+            "X-Webhook-ID": payload.webhook_id,
+            **self.headers,
+        }
+        if self.secret:
+            request_headers["X-Webhook-Signature"] = self.sign(body)
+
+        delivery = WebhookDelivery(payload=payload)
+
+        for attempt in range(self.max_retries):
+            delivery.attempts = attempt + 1
+            start = time.monotonic()
+            try:
+                resp = requests.post(
+                    self.url,
+                    data=body,
+                    headers=request_headers,
+                    timeout=self.timeout,
+                )
+                delivery.status_code = resp.status_code
+                delivery.duration_ms = (time.monotonic() - start) * 1000
+                delivery.success = 200 <= resp.status_code < 300
+                if delivery.success:
+                    logger.info(
+                        "Webhook %s delivered (%d ms)",
+                        payload.webhook_id,
+                        int(delivery.duration_ms),
+                    )
+                    break
+                delivery.error = f"HTTP {resp.status_code}"
+            except Exception as e:
+                delivery.duration_ms = (time.monotonic() - start) * 1000
+                delivery.error = str(e)
+
+            if attempt < self.max_retries - 1:
+                backoff = 2**attempt
+                logger.warning(
+                    "Webhook %s attempt %d failed (%s), retrying in %ds",
+                    payload.webhook_id,
+                    attempt + 1,
+                    delivery.error,
+                    backoff,
+                )
+                time.sleep(backoff)
+
+        if not delivery.success:
+            logger.error(
+                "Webhook %s failed after %d attempts: %s",
+                payload.webhook_id,
+                delivery.attempts,
+                delivery.error,
+            )
+
+        self._deliveries.append(delivery)
+        return delivery
+
+    @property
+    def deliveries(self) -> list[WebhookDelivery]:
+        """All delivery attempts in chronological order."""
+        return list(self._deliveries)
+
+    @property
+    def success_rate(self) -> float:
+        """Fraction of successful deliveries (0.0 - 1.0)."""
+        if not self._deliveries:
+            return 0.0
+        successes = sum(1 for d in self._deliveries if d.success)
+        return successes / len(self._deliveries)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,244 @@
+"""Tests for webhook notification system."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from landmarkdiff.webhooks import (
+    EVENT_TYPES,
+    WebhookNotifier,
+    WebhookPayload,
+)
+
+
+class TestWebhookPayload:
+    def test_creates_with_event_and_data(self):
+        p = WebhookPayload(event="prediction.complete", data={"status": "ok"})
+        assert p.event == "prediction.complete"
+        assert p.data["status"] == "ok"
+
+    def test_auto_generates_webhook_id(self):
+        p = WebhookPayload(event="test", data={})
+        assert len(p.webhook_id) == 12
+
+    def test_unique_ids(self):
+        ids = {WebhookPayload(event="test", data={}).webhook_id for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_to_dict(self):
+        p = WebhookPayload(event="test", data={"key": "val"})
+        d = p.to_dict()
+        assert d["event"] == "test"
+        assert d["data"] == {"key": "val"}
+        assert "webhook_id" in d
+        assert "timestamp" in d
+
+    def test_to_json_is_valid(self):
+        import json
+
+        p = WebhookPayload(event="test", data={"x": 1})
+        parsed = json.loads(p.to_json())
+        assert parsed["event"] == "test"
+
+
+class TestEventTypes:
+    def test_known_events(self):
+        assert "prediction.complete" in EVENT_TYPES
+        assert "batch.complete" in EVENT_TYPES
+        assert "batch.failed" in EVENT_TYPES
+
+    def test_event_count(self):
+        assert len(EVENT_TYPES) == 9
+
+
+class TestWebhookNotifierInit:
+    def test_default_config(self):
+        n = WebhookNotifier("https://example.com/hook")
+        assert n.url == "https://example.com/hook"
+        assert n.secret is None
+        assert n.max_retries == 3
+        assert n.timeout == 10.0
+
+    def test_custom_config(self):
+        n = WebhookNotifier(
+            "https://example.com",
+            secret="mysecret",
+            max_retries=5,
+            timeout=30.0,
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert n.secret == "mysecret"
+        assert n.max_retries == 5
+        assert n.headers["Authorization"] == "Bearer tok"
+
+
+class TestWebhookSigning:
+    def test_sign_produces_hex(self):
+        n = WebhookNotifier("https://x.com", secret="test_secret")
+        sig = n.sign('{"event":"test"}')
+        assert len(sig) == 64  # SHA-256 hex digest
+
+    def test_sign_requires_secret(self):
+        n = WebhookNotifier("https://x.com")
+        with pytest.raises(ValueError, match="No signing secret"):
+            n.sign("body")
+
+    def test_verify_correct_signature(self):
+        n = WebhookNotifier("https://x.com", secret="s3cret")
+        body = '{"event":"test"}'
+        sig = n.sign(body)
+        assert n.verify(body, sig) is True
+
+    def test_verify_wrong_signature(self):
+        n = WebhookNotifier("https://x.com", secret="s3cret")
+        assert n.verify('{"event":"test"}', "wrong") is False
+
+    def test_verify_without_secret(self):
+        n = WebhookNotifier("https://x.com")
+        assert n.verify("body", "sig") is False
+
+    def test_different_bodies_different_sigs(self):
+        n = WebhookNotifier("https://x.com", secret="key")
+        sig1 = n.sign("body1")
+        sig2 = n.sign("body2")
+        assert sig1 != sig2
+
+
+class TestWebhookSend:
+    @patch("landmarkdiff.webhooks.time.sleep")
+    def test_successful_delivery(self, mock_sleep):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        n = WebhookNotifier("https://hook.example.com")
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            delivery = n.send("prediction.complete", {"id": "abc"})
+
+        assert delivery.success is True
+        assert delivery.status_code == 200
+        assert delivery.attempts == 1
+        mock_post.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("landmarkdiff.webhooks.time.sleep")
+    def test_retry_on_server_error(self, mock_sleep):
+        fail_resp = MagicMock()
+        fail_resp.status_code = 500
+
+        ok_resp = MagicMock()
+        ok_resp.status_code = 200
+
+        n = WebhookNotifier("https://hook.example.com", max_retries=3)
+        with patch("requests.post", side_effect=[fail_resp, ok_resp]):
+            delivery = n.send("test", {})
+
+        assert delivery.success is True
+        assert delivery.attempts == 2
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("landmarkdiff.webhooks.time.sleep")
+    def test_all_retries_exhausted(self, mock_sleep):
+        fail_resp = MagicMock()
+        fail_resp.status_code = 503
+
+        n = WebhookNotifier("https://hook.example.com", max_retries=3)
+        with patch("requests.post", return_value=fail_resp):
+            delivery = n.send("test", {})
+
+        assert delivery.success is False
+        assert delivery.attempts == 3
+        assert mock_sleep.call_count == 2  # backoff between retries
+
+    @patch("landmarkdiff.webhooks.time.sleep")
+    def test_retry_on_connection_error(self, mock_sleep):
+        ok_resp = MagicMock()
+        ok_resp.status_code = 200
+
+        n = WebhookNotifier("https://hook.example.com", max_retries=3)
+        with patch(
+            "requests.post",
+            side_effect=[ConnectionError("refused"), ok_resp],
+        ):
+            delivery = n.send("test", {})
+
+        assert delivery.success is True
+        assert delivery.attempts == 2
+
+    @patch("landmarkdiff.webhooks.time.sleep")
+    def test_includes_signature_header(self, mock_sleep):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        n = WebhookNotifier("https://hook.example.com", secret="key123")
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            n.send("test", {"val": 1})
+
+        call_kwargs = mock_post.call_args
+        headers = call_kwargs.kwargs.get("headers", call_kwargs[1].get("headers", {}))
+        assert "X-Webhook-Signature" in headers
+        assert "X-Webhook-Event" in headers
+
+    @patch("landmarkdiff.webhooks.time.sleep")
+    def test_includes_custom_headers(self, mock_sleep):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        n = WebhookNotifier(
+            "https://hook.example.com",
+            headers={"Authorization": "Bearer xyz"},
+        )
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            n.send("test", {})
+
+        call_kwargs = mock_post.call_args
+        headers = call_kwargs.kwargs.get("headers", call_kwargs[1].get("headers", {}))
+        assert headers["Authorization"] == "Bearer xyz"
+
+    @patch("landmarkdiff.webhooks.time.sleep")
+    def test_delivery_tracking(self, mock_sleep):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        n = WebhookNotifier("https://hook.example.com")
+        with patch("requests.post", return_value=mock_resp):
+            n.send("event1", {})
+            n.send("event2", {})
+
+        assert len(n.deliveries) == 2
+        assert n.deliveries[0].payload.event == "event1"
+        assert n.deliveries[1].payload.event == "event2"
+
+
+class TestWebhookMetrics:
+    @patch("landmarkdiff.webhooks.time.sleep")
+    def test_success_rate_all_ok(self, mock_sleep):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        n = WebhookNotifier("https://hook.example.com")
+        with patch("requests.post", return_value=mock_resp):
+            n.send("e1", {})
+            n.send("e2", {})
+
+        assert n.success_rate == 1.0
+
+    @patch("landmarkdiff.webhooks.time.sleep")
+    def test_success_rate_mixed(self, mock_sleep):
+        ok_resp = MagicMock()
+        ok_resp.status_code = 200
+
+        fail_resp = MagicMock()
+        fail_resp.status_code = 500
+
+        n = WebhookNotifier("https://hook.example.com", max_retries=1)
+        with patch("requests.post", side_effect=[ok_resp, fail_resp]):
+            n.send("ok", {})
+            n.send("fail", {})
+
+        assert n.success_rate == 0.5
+
+    def test_success_rate_no_deliveries(self):
+        n = WebhookNotifier("https://hook.example.com")
+        assert n.success_rate == 0.0


### PR DESCRIPTION
## Summary
- Adds `WebhookNotifier` in `landmarkdiff/webhooks.py` for HTTP POST event callbacks
- Exponential backoff retry (1s, 2s, 4s) on delivery failures
- Optional HMAC-SHA256 payload signing with `X-Webhook-Signature` header
- 9 event types: prediction/batch/analysis lifecycle events
- Delivery tracking with success rate metrics
- 25 tests covering payload, signing, delivery, retry, and metrics

Closes #214

## Test plan
- [x] All 25 tests pass locally
- [ ] CI lint passes
- [ ] CI type-check passes
- [ ] CI tests pass on 3.10/3.11/3.12