### PR TITLE
Add OpenTelemetry tracing and Grafana dashboard template

### DIFF
--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -1,0 +1,294 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source for LandmarkDiff metrics",
+      "type": "datasource",
+      "pluginId": "prometheus"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "LandmarkDiff inference pipeline monitoring dashboard",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Overview",
+      "type": "row",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "collapsed": false
+    },
+    {
+      "title": "Predictions / min",
+      "type": "stat",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "targets": [
+        {
+          "expr": "sum(rate(landmarkdiff_predictions_total[5m])) * 60",
+          "legendFormat": "predictions/min"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "steps": [
+              {"color": "red", "value": 0},
+              {"color": "yellow", "value": 1},
+              {"color": "green", "value": 5}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Success Rate",
+      "type": "gauge",
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+      "targets": [
+        {
+          "expr": "sum(rate(landmarkdiff_predictions_total{status=\"success\"}[5m])) / sum(rate(landmarkdiff_predictions_total[5m])) * 100",
+          "legendFormat": "success %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "steps": [
+              {"color": "red", "value": 0},
+              {"color": "yellow", "value": 95},
+              {"color": "green", "value": 99}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Avg Latency (p50)",
+      "type": "stat",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, rate(landmarkdiff_inference_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "steps": [
+              {"color": "green", "value": 0},
+              {"color": "yellow", "value": 2},
+              {"color": "red", "value": 5}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "GPU VRAM Usage",
+      "type": "stat",
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
+      "targets": [
+        {
+          "expr": "landmarkdiff_gpu_vram_used_bytes / 1073741824",
+          "legendFormat": "{{gpu}} GB"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decgbytes",
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "steps": [
+              {"color": "green", "value": 0},
+              {"color": "yellow", "value": 8},
+              {"color": "red", "value": 16}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Latency",
+      "type": "row",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 5},
+      "collapsed": false
+    },
+    {
+      "title": "Inference Latency Distribution",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 6},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, rate(landmarkdiff_inference_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(landmarkdiff_inference_duration_seconds_bucket[5m]))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(landmarkdiff_inference_duration_seconds_bucket[5m]))",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {"lineWidth": 2, "fillOpacity": 10}
+        }
+      }
+    },
+    {
+      "title": "Latency by Pipeline Stage",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6},
+      "targets": [
+        {
+          "expr": "rate(landmarkdiff_stage_duration_seconds_sum[5m]) / rate(landmarkdiff_stage_duration_seconds_count[5m])",
+          "legendFormat": "{{stage}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {"lineWidth": 2, "fillOpacity": 10, "stacking": {"mode": "normal"}}
+        }
+      }
+    },
+    {
+      "title": "Throughput",
+      "type": "row",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+      "collapsed": false
+    },
+    {
+      "title": "Predictions by Procedure",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+      "targets": [
+        {
+          "expr": "sum by (procedure) (rate(landmarkdiff_predictions_total[5m])) * 60",
+          "legendFormat": "{{procedure}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {"lineWidth": 2, "fillOpacity": 20}
+        }
+      }
+    },
+    {
+      "title": "Error Rate by Type",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+      "targets": [
+        {
+          "expr": "sum by (error_type) (rate(landmarkdiff_errors_total[5m])) * 60",
+          "legendFormat": "{{error_type}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {"lineWidth": 2, "fillOpacity": 20, "drawStyle": "bars"}
+        }
+      }
+    },
+    {
+      "title": "Resources",
+      "type": "row",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 23},
+      "collapsed": false
+    },
+    {
+      "title": "GPU Utilization %",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 24},
+      "targets": [
+        {
+          "expr": "landmarkdiff_gpu_utilization_percent",
+          "legendFormat": "GPU {{gpu}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {"lineWidth": 2, "fillOpacity": 30}
+        }
+      }
+    },
+    {
+      "title": "VRAM Usage Over Time",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 24},
+      "targets": [
+        {
+          "expr": "landmarkdiff_gpu_vram_used_bytes / 1073741824",
+          "legendFormat": "Used GB (GPU {{gpu}})"
+        },
+        {
+          "expr": "landmarkdiff_gpu_vram_total_bytes / 1073741824",
+          "legendFormat": "Total GB (GPU {{gpu}})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decgbytes",
+          "custom": {"lineWidth": 2, "fillOpacity": 15}
+        }
+      }
+    },
+    {
+      "title": "Batch Queue Depth",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 24},
+      "targets": [
+        {
+          "expr": "landmarkdiff_batch_queue_size",
+          "legendFormat": "queue depth"
+        },
+        {
+          "expr": "landmarkdiff_batch_processing",
+          "legendFormat": "in-flight"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {"lineWidth": 2, "fillOpacity": 20}
+        }
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["landmarkdiff", "inference", "gpu"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "LandmarkDiff Inference Pipeline",
+  "uid": "landmarkdiff-inference",
+  "version": 1
+}

--- a/landmarkdiff/tracing.py
+++ b/landmarkdiff/tracing.py
@@ -1,0 +1,152 @@
+"""OpenTelemetry tracing utilities for the inference pipeline.
+
+Provides span creation and attribute recording for each pipeline stage,
+enabling distributed tracing in production deployments. Falls back to
+no-op when OpenTelemetry is not installed.
+
+Usage:
+    from landmarkdiff.tracing import get_tracer, trace_stage
+
+    tracer = get_tracer()
+
+    with trace_stage(tracer, "landmark_extraction", procedure="rhinoplasty"):
+        landmarks = extract_landmarks(image)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_TRACER_NAME = "landmarkdiff"
+_TRACER_VERSION = "0.2.0"
+
+
+class _NoOpSpan:
+    """Minimal span stub when OpenTelemetry is not available."""
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        pass
+
+    def set_status(self, status: Any) -> None:
+        pass
+
+    def record_exception(self, exc: BaseException) -> None:
+        pass
+
+    def end(self) -> None:
+        pass
+
+    def __enter__(self) -> _NoOpSpan:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+class _NoOpTracer:
+    """Minimal tracer stub when OpenTelemetry is not available."""
+
+    def start_span(self, name: str, **kwargs: Any) -> _NoOpSpan:
+        return _NoOpSpan()
+
+    def start_as_current_span(self, name: str, **kwargs: Any) -> _NoOpSpan:
+        return _NoOpSpan()
+
+
+def get_tracer(name: str = _TRACER_NAME) -> Any:
+    """Get an OpenTelemetry tracer, falling back to a no-op stub.
+
+    Args:
+        name: Tracer instrumentation name.
+
+    Returns:
+        An OpenTelemetry Tracer or a no-op stub.
+    """
+    try:
+        from opentelemetry import trace
+
+        return trace.get_tracer(name, _TRACER_VERSION)
+    except ImportError:
+        logger.debug("OpenTelemetry not installed, using no-op tracer")
+        return _NoOpTracer()
+
+
+@contextmanager
+def trace_stage(
+    tracer: Any,
+    stage_name: str,
+    *,
+    procedure: str = "",
+    resolution: int = 0,
+    intensity: float = 0.0,
+    attributes: dict[str, Any] | None = None,
+) -> Generator[Any, None, None]:
+    """Context manager that wraps a pipeline stage in a tracing span.
+
+    Records timing, procedure metadata, and any exceptions as span events.
+    Works with both real OpenTelemetry tracers and the no-op stub.
+
+    Args:
+        tracer: Tracer instance from get_tracer().
+        stage_name: Name for the span (e.g. "landmark_extraction").
+        procedure: Surgical procedure type.
+        resolution: Image resolution in pixels.
+        intensity: Procedure intensity (0-100).
+        attributes: Extra key-value attributes to record.
+
+    Yields:
+        The span object (real or no-op).
+    """
+    span = tracer.start_span(f"landmarkdiff.{stage_name}")
+    start = time.monotonic()
+
+    try:
+        if procedure:
+            span.set_attribute("landmarkdiff.procedure", procedure)
+        if resolution > 0:
+            span.set_attribute("landmarkdiff.resolution", resolution)
+        if intensity > 0:
+            span.set_attribute("landmarkdiff.intensity", intensity)
+
+        if attributes:
+            for key, val in attributes.items():
+                span.set_attribute(f"landmarkdiff.{key}", val)
+
+        yield span
+
+        elapsed_ms = (time.monotonic() - start) * 1000
+        span.set_attribute("landmarkdiff.duration_ms", round(elapsed_ms, 2))
+
+    except Exception as exc:
+        elapsed_ms = (time.monotonic() - start) * 1000
+        span.set_attribute("landmarkdiff.duration_ms", round(elapsed_ms, 2))
+        with contextlib.suppress(Exception):
+            span.record_exception(exc)
+            span.set_attribute("landmarkdiff.error", str(exc))
+        raise
+    finally:
+        span.end()
+
+
+# Standard pipeline stage names for consistent instrumentation
+PIPELINE_SPAN_NAMES = (
+    "model_loading",
+    "landmark_extraction",
+    "displacement_computation",
+    "mesh_deformation",
+    "controlnet_conditioning",
+    "diffusion_inference",
+    "vae_decode",
+    "postprocessing",
+    "face_restoration",
+    "upscaling",
+    "compositing",
+    "output_encoding",
+)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,180 @@
+"""Tests for OpenTelemetry tracing utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from landmarkdiff.tracing import (
+    PIPELINE_SPAN_NAMES,
+    _NoOpSpan,
+    _NoOpTracer,
+    get_tracer,
+    trace_stage,
+)
+
+
+class TestNoOpSpan:
+    def test_set_attribute_noop(self):
+        span = _NoOpSpan()
+        span.set_attribute("key", "val")  # should not raise
+
+    def test_set_status_noop(self):
+        span = _NoOpSpan()
+        span.set_status("OK")
+
+    def test_record_exception_noop(self):
+        span = _NoOpSpan()
+        span.record_exception(ValueError("test"))
+
+    def test_end_noop(self):
+        span = _NoOpSpan()
+        span.end()
+
+    def test_context_manager(self):
+        with _NoOpSpan() as span:
+            span.set_attribute("inside", True)
+
+
+class TestNoOpTracer:
+    def test_start_span_returns_noop(self):
+        tracer = _NoOpTracer()
+        span = tracer.start_span("test")
+        assert isinstance(span, _NoOpSpan)
+
+    def test_start_as_current_span_returns_noop(self):
+        tracer = _NoOpTracer()
+        span = tracer.start_as_current_span("test")
+        assert isinstance(span, _NoOpSpan)
+
+
+class TestGetTracer:
+    def test_returns_tracer(self):
+        tracer = get_tracer()
+        # Without otel installed, should get NoOpTracer
+        assert hasattr(tracer, "start_span")
+
+    def test_custom_name(self):
+        tracer = get_tracer("custom")
+        assert hasattr(tracer, "start_span")
+
+
+class TestTraceStage:
+    def test_basic_stage(self):
+        tracer = _NoOpTracer()
+        with trace_stage(tracer, "test_stage") as span:
+            assert isinstance(span, _NoOpSpan)
+
+    def test_with_procedure(self):
+        tracer = _NoOpTracer()
+        with trace_stage(tracer, "extract", procedure="rhinoplasty"):
+            pass  # should not raise
+
+    def test_with_all_attributes(self):
+        tracer = _NoOpTracer()
+        with trace_stage(
+            tracer,
+            "inference",
+            procedure="blepharoplasty",
+            resolution=512,
+            intensity=65.0,
+            attributes={"batch_size": 4, "seed": 42},
+        ):
+            pass
+
+    def test_exception_propagated(self):
+        tracer = _NoOpTracer()
+        with pytest.raises(ValueError, match="test error"), trace_stage(tracer, "failing_stage"):
+            raise ValueError("test error")
+
+    def test_span_receives_attributes(self):
+        """Verify attributes are set on the span."""
+        recorded: dict[str, object] = {}
+
+        class _TrackingSpan(_NoOpSpan):
+            def set_attribute(self, key: str, value: object) -> None:
+                recorded[key] = value
+
+        class _TrackingTracer(_NoOpTracer):
+            def start_span(self, name: str, **kwargs: object) -> _TrackingSpan:
+                return _TrackingSpan()
+
+        tracer = _TrackingTracer()
+        with trace_stage(
+            tracer,
+            "test",
+            procedure="rhinoplasty",
+            resolution=256,
+            intensity=50.0,
+        ):
+            pass
+
+        assert recorded["landmarkdiff.procedure"] == "rhinoplasty"
+        assert recorded["landmarkdiff.resolution"] == 256
+        assert recorded["landmarkdiff.intensity"] == 50.0
+        assert "landmarkdiff.duration_ms" in recorded
+
+    def test_exception_recorded_on_span(self):
+        """Verify exceptions are recorded on the span."""
+        exceptions: list[BaseException] = []
+
+        class _ExcSpan(_NoOpSpan):
+            def record_exception(self, exc: BaseException) -> None:
+                exceptions.append(exc)
+
+        class _ExcTracer(_NoOpTracer):
+            def start_span(self, name: str, **kwargs: object) -> _ExcSpan:
+                return _ExcSpan()
+
+        tracer = _ExcTracer()
+        with pytest.raises(RuntimeError), trace_stage(tracer, "fail"):
+            raise RuntimeError("boom")
+
+        assert len(exceptions) == 1
+        assert str(exceptions[0]) == "boom"
+
+    def test_span_ended_after_success(self):
+        ended = []
+
+        class _EndSpan(_NoOpSpan):
+            def end(self) -> None:
+                ended.append(True)
+
+        class _EndTracer(_NoOpTracer):
+            def start_span(self, name: str, **kwargs: object) -> _EndSpan:
+                return _EndSpan()
+
+        tracer = _EndTracer()
+        with trace_stage(tracer, "test"):
+            pass
+        assert len(ended) == 1
+
+    def test_span_ended_after_error(self):
+        ended = []
+
+        class _EndSpan(_NoOpSpan):
+            def end(self) -> None:
+                ended.append(True)
+
+        class _EndTracer(_NoOpTracer):
+            def start_span(self, name: str, **kwargs: object) -> _EndSpan:
+                return _EndSpan()
+
+        tracer = _EndTracer()
+        with pytest.raises(ValueError), trace_stage(tracer, "test"):
+            raise ValueError("err")
+        assert len(ended) == 1
+
+
+class TestPipelineSpanNames:
+    def test_contains_key_stages(self):
+        assert "landmark_extraction" in PIPELINE_SPAN_NAMES
+        assert "diffusion_inference" in PIPELINE_SPAN_NAMES
+        assert "postprocessing" in PIPELINE_SPAN_NAMES
+
+    def test_count(self):
+        assert len(PIPELINE_SPAN_NAMES) == 12
+
+    def test_all_strings(self):
+        for name in PIPELINE_SPAN_NAMES:
+            assert isinstance(name, str)
+            assert len(name) > 0


### PR DESCRIPTION
## Summary
- Adds `landmarkdiff/tracing.py` with span-based pipeline instrumentation
- No-op tracer/span stubs when OpenTelemetry is not installed (zero-cost)
- `trace_stage()` context manager records timing, procedure metadata, and exceptions
- 12 standard pipeline span names for consistent instrumentation
- Grafana dashboard JSON template with 14 panels covering latency, throughput, errors, and GPU metrics
- 20 tests for tracing utilities

Closes #106
Closes #110

## Test plan
- [x] All 20 tracing tests pass locally
- [ ] CI lint passes
- [ ] CI type-check passes
- [ ] CI tests pass on 3.10/3.11/3.12