### PR TITLE
Add WebSocket streaming protocol for real-time preview

### DIFF
--- a/landmarkdiff/streaming.py
+++ b/landmarkdiff/streaming.py
@@ -1,0 +1,267 @@
+"""WebSocket streaming protocol for real-time prediction preview.
+
+Defines the message protocol and frame generator for streaming
+progressive prediction results over WebSocket connections.
+
+Usage with FastAPI:
+    from fastapi import WebSocket
+    from landmarkdiff.streaming import StreamSession, FrameMessage
+
+    @app.websocket("/ws/predict")
+    async def ws_predict(websocket: WebSocket):
+        await websocket.accept()
+        session = StreamSession.from_websocket_params(await websocket.receive_json())
+        async for frame_msg in session.generate_frames():
+            await websocket.send_json(frame_msg.to_dict())
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class MessageType(str, Enum):
+    """WebSocket message types for the streaming protocol."""
+
+    CONNECT = "connect"
+    START = "start"
+    FRAME = "frame"
+    PROGRESS = "progress"
+    COMPLETE = "complete"
+    ERROR = "error"
+    CANCEL = "cancel"
+
+
+@dataclass
+class StreamConfig:
+    """Configuration for a streaming prediction session.
+
+    Args:
+        procedure: Surgical procedure name.
+        intensity: Target intensity (0-100).
+        n_preview_frames: Number of intermediate preview frames.
+        preview_interval_ms: Minimum time between preview frames.
+        resolution: Image resolution.
+        seed: Random seed.
+        quality: JPEG quality for frame encoding (1-100).
+    """
+
+    procedure: str = "rhinoplasty"
+    intensity: float = 65.0
+    n_preview_frames: int = 5
+    preview_interval_ms: int = 200
+    resolution: int = 512
+    seed: int = 42
+    quality: int = 80
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StreamConfig:
+        """Create config from a dictionary, ignoring unknown keys."""
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(**filtered)
+
+
+@dataclass
+class FrameMessage:
+    """A single frame message in the streaming protocol."""
+
+    msg_type: MessageType
+    session_id: str
+    frame_index: int = 0
+    total_frames: int = 0
+    progress: float = 0.0
+    image_b64: str = ""
+    stage: str = ""
+    description: str = ""
+    error: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "type": self.msg_type.value,
+            "session_id": self.session_id,
+            "timestamp": self.timestamp,
+        }
+        if self.msg_type == MessageType.FRAME:
+            d["frame_index"] = self.frame_index
+            d["total_frames"] = self.total_frames
+            d["image"] = self.image_b64
+            d["progress"] = round(self.progress, 3)
+        elif self.msg_type == MessageType.PROGRESS:
+            d["progress"] = round(self.progress, 3)
+            d["stage"] = self.stage
+            d["description"] = self.description
+        elif self.msg_type == MessageType.ERROR:
+            d["error"] = self.error
+        elif self.msg_type == MessageType.COMPLETE:
+            d["image"] = self.image_b64
+            d["metadata"] = self.metadata
+        return d
+
+
+def encode_frame(image: np.ndarray, quality: int = 80) -> str:
+    """Encode a BGR image as a base64 JPEG string.
+
+    Args:
+        image: BGR image array.
+        quality: JPEG quality (1-100).
+
+    Returns:
+        Base64-encoded JPEG string.
+    """
+    params = [cv2.IMWRITE_JPEG_QUALITY, max(1, min(100, quality))]
+    _, buf = cv2.imencode(".jpg", image, params)
+    return base64.b64encode(buf.tobytes()).decode("ascii")
+
+
+class StreamSession:
+    """Manages a single streaming prediction session.
+
+    Generates progressive preview frames by interpolating between
+    the original and predicted images, sending them as WebSocket
+    messages at the configured interval.
+
+    Args:
+        config: Stream configuration.
+        session_id: Unique session identifier (auto-generated if not given).
+    """
+
+    def __init__(
+        self,
+        config: StreamConfig | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        self.config = config or StreamConfig()
+        self.session_id = session_id or uuid.uuid4().hex[:12]
+        self.cancelled = False
+        self._start_time = 0.0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StreamSession:
+        """Create a session from WebSocket message data."""
+        config = StreamConfig.from_dict(data.get("config", data))
+        return cls(config=config, session_id=data.get("session_id"))
+
+    def cancel(self) -> None:
+        """Cancel the streaming session."""
+        self.cancelled = True
+
+    def generate_preview_frames(
+        self,
+        original: np.ndarray,
+        prediction: np.ndarray,
+    ) -> list[FrameMessage]:
+        """Generate a sequence of progressive preview frame messages.
+
+        Creates alpha-blended intermediate frames between original and
+        prediction, encoding each as a JPEG for WebSocket transmission.
+
+        Args:
+            original: BGR original image.
+            prediction: BGR predicted image.
+
+        Returns:
+            List of FrameMessage objects for streaming.
+        """
+        if original.shape != prediction.shape:
+            return [
+                FrameMessage(
+                    msg_type=MessageType.ERROR,
+                    session_id=self.session_id,
+                    error=f"Shape mismatch: {original.shape} vs {prediction.shape}",
+                )
+            ]
+
+        n = self.config.n_preview_frames
+        if n < 1:
+            n = 1
+
+        orig_f = original.astype(np.float32)
+        pred_f = prediction.astype(np.float32)
+        messages: list[FrameMessage] = []
+
+        for i in range(n):
+            if self.cancelled:
+                break
+
+            alpha = (i + 1) / n
+            blended = np.clip(orig_f * (1.0 - alpha) + pred_f * alpha, 0, 255).astype(np.uint8)
+
+            messages.append(
+                FrameMessage(
+                    msg_type=MessageType.FRAME,
+                    session_id=self.session_id,
+                    frame_index=i,
+                    total_frames=n,
+                    progress=alpha,
+                    image_b64=encode_frame(blended, self.config.quality),
+                )
+            )
+
+        if not self.cancelled:
+            messages.append(
+                FrameMessage(
+                    msg_type=MessageType.COMPLETE,
+                    session_id=self.session_id,
+                    image_b64=encode_frame(prediction, self.config.quality),
+                    metadata={
+                        "procedure": self.config.procedure,
+                        "intensity": self.config.intensity,
+                        "resolution": self.config.resolution,
+                    },
+                )
+            )
+
+        return messages
+
+    def make_progress_message(
+        self,
+        progress: float,
+        stage: str,
+        description: str = "",
+    ) -> FrameMessage:
+        """Create a progress update message.
+
+        Args:
+            progress: Completion fraction (0.0 - 1.0).
+            stage: Current pipeline stage name.
+            description: Human-readable description.
+
+        Returns:
+            A progress-type FrameMessage.
+        """
+        return FrameMessage(
+            msg_type=MessageType.PROGRESS,
+            session_id=self.session_id,
+            progress=progress,
+            stage=stage,
+            description=description,
+        )
+
+    def make_error_message(self, error: str) -> FrameMessage:
+        """Create an error message.
+
+        Args:
+            error: Error description.
+
+        Returns:
+            An error-type FrameMessage.
+        """
+        return FrameMessage(
+            msg_type=MessageType.ERROR,
+            session_id=self.session_id,
+            error=error,
+        )

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,249 @@
+"""Tests for WebSocket streaming protocol."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import numpy as np
+import pytest
+
+from landmarkdiff.streaming import (
+    FrameMessage,
+    MessageType,
+    StreamConfig,
+    StreamSession,
+    encode_frame,
+)
+
+
+@pytest.fixture
+def sample_images():
+    """Create a pair of small test images."""
+    original = np.zeros((64, 64, 3), dtype=np.uint8)
+    original[:, :, 2] = 200  # red
+    prediction = np.zeros((64, 64, 3), dtype=np.uint8)
+    prediction[:, :, 0] = 200  # blue
+    return original, prediction
+
+
+class TestMessageType:
+    def test_all_types_are_strings(self):
+        for mt in MessageType:
+            assert isinstance(mt.value, str)
+
+    def test_expected_types_exist(self):
+        assert MessageType.FRAME.value == "frame"
+        assert MessageType.COMPLETE.value == "complete"
+        assert MessageType.ERROR.value == "error"
+        assert MessageType.PROGRESS.value == "progress"
+
+
+class TestStreamConfig:
+    def test_defaults(self):
+        cfg = StreamConfig()
+        assert cfg.procedure == "rhinoplasty"
+        assert cfg.intensity == 65.0
+        assert cfg.n_preview_frames == 5
+        assert cfg.quality == 80
+
+    def test_from_dict(self):
+        cfg = StreamConfig.from_dict(
+            {
+                "procedure": "blepharoplasty",
+                "intensity": 80.0,
+                "quality": 90,
+            }
+        )
+        assert cfg.procedure == "blepharoplasty"
+        assert cfg.intensity == 80.0
+        assert cfg.quality == 90
+
+    def test_from_dict_ignores_unknown(self):
+        cfg = StreamConfig.from_dict(
+            {
+                "procedure": "rhinoplasty",
+                "unknown_field": "ignored",
+            }
+        )
+        assert cfg.procedure == "rhinoplasty"
+        assert not hasattr(cfg, "unknown_field")
+
+
+class TestFrameMessage:
+    def test_frame_to_dict(self):
+        msg = FrameMessage(
+            msg_type=MessageType.FRAME,
+            session_id="abc123",
+            frame_index=2,
+            total_frames=5,
+            progress=0.4,
+            image_b64="base64data",
+        )
+        d = msg.to_dict()
+        assert d["type"] == "frame"
+        assert d["session_id"] == "abc123"
+        assert d["frame_index"] == 2
+        assert d["image"] == "base64data"
+        assert d["progress"] == 0.4
+
+    def test_progress_to_dict(self):
+        msg = FrameMessage(
+            msg_type=MessageType.PROGRESS,
+            session_id="abc123",
+            progress=0.75,
+            stage="diffusion_inference",
+            description="Running denoising",
+        )
+        d = msg.to_dict()
+        assert d["type"] == "progress"
+        assert d["stage"] == "diffusion_inference"
+        assert d["progress"] == 0.75
+
+    def test_error_to_dict(self):
+        msg = FrameMessage(
+            msg_type=MessageType.ERROR,
+            session_id="abc123",
+            error="No face detected",
+        )
+        d = msg.to_dict()
+        assert d["type"] == "error"
+        assert d["error"] == "No face detected"
+
+    def test_complete_to_dict(self):
+        msg = FrameMessage(
+            msg_type=MessageType.COMPLETE,
+            session_id="abc123",
+            image_b64="final_image",
+            metadata={"procedure": "rhinoplasty"},
+        )
+        d = msg.to_dict()
+        assert d["type"] == "complete"
+        assert d["image"] == "final_image"
+        assert d["metadata"]["procedure"] == "rhinoplasty"
+
+    def test_to_dict_is_json_serializable(self):
+        msg = FrameMessage(
+            msg_type=MessageType.FRAME,
+            session_id="test",
+            frame_index=0,
+            total_frames=3,
+            image_b64="data",
+        )
+        serialized = json.dumps(msg.to_dict())
+        assert isinstance(serialized, str)
+
+
+class TestEncodeFrame:
+    def test_returns_base64_string(self):
+        img = np.zeros((32, 32, 3), dtype=np.uint8)
+        b64 = encode_frame(img)
+        assert isinstance(b64, str)
+        assert len(b64) > 0
+
+    def test_decodable(self):
+        img = np.full((32, 32, 3), 128, dtype=np.uint8)
+        b64 = encode_frame(img)
+        decoded = base64.b64decode(b64)
+        assert len(decoded) > 0
+
+    def test_quality_affects_size(self):
+        img = np.random.default_rng(0).integers(0, 255, (64, 64, 3), dtype=np.uint8)
+        low = encode_frame(img, quality=10)
+        high = encode_frame(img, quality=95)
+        assert len(low) < len(high)
+
+    def test_clamps_quality(self):
+        img = np.zeros((16, 16, 3), dtype=np.uint8)
+        # should not raise with out-of-range quality
+        encode_frame(img, quality=0)
+        encode_frame(img, quality=200)
+
+
+class TestStreamSession:
+    def test_creates_with_defaults(self):
+        session = StreamSession()
+        assert session.config.procedure == "rhinoplasty"
+        assert len(session.session_id) == 12
+
+    def test_creates_from_dict(self):
+        session = StreamSession.from_dict(
+            {
+                "config": {"procedure": "blepharoplasty", "intensity": 40.0},
+                "session_id": "custom_id",
+            }
+        )
+        assert session.config.procedure == "blepharoplasty"
+        assert session.session_id == "custom_id"
+
+    def test_generate_preview_frames_count(self, sample_images):
+        original, prediction = sample_images
+        config = StreamConfig(n_preview_frames=3)
+        session = StreamSession(config=config)
+        messages = session.generate_preview_frames(original, prediction)
+        # 3 frames + 1 complete
+        assert len(messages) == 4
+        assert messages[-1].msg_type == MessageType.COMPLETE
+
+    def test_frame_progress_increases(self, sample_images):
+        original, prediction = sample_images
+        config = StreamConfig(n_preview_frames=5)
+        session = StreamSession(config=config)
+        messages = session.generate_preview_frames(original, prediction)
+        frame_msgs = [m for m in messages if m.msg_type == MessageType.FRAME]
+        progresses = [m.progress for m in frame_msgs]
+        assert progresses == sorted(progresses)
+        assert progresses[-1] == pytest.approx(1.0)
+
+    def test_frames_have_images(self, sample_images):
+        original, prediction = sample_images
+        config = StreamConfig(n_preview_frames=2)
+        session = StreamSession(config=config)
+        messages = session.generate_preview_frames(original, prediction)
+        for msg in messages:
+            if msg.msg_type in (MessageType.FRAME, MessageType.COMPLETE):
+                assert len(msg.image_b64) > 0
+
+    def test_cancel_stops_generation(self, sample_images):
+        original, prediction = sample_images
+        config = StreamConfig(n_preview_frames=10)
+        session = StreamSession(config=config)
+        session.cancel()
+        messages = session.generate_preview_frames(original, prediction)
+        assert len(messages) == 0  # cancelled before any frames
+
+    def test_shape_mismatch_returns_error(self):
+        img1 = np.zeros((64, 64, 3), dtype=np.uint8)
+        img2 = np.zeros((32, 32, 3), dtype=np.uint8)
+        session = StreamSession()
+        messages = session.generate_preview_frames(img1, img2)
+        assert len(messages) == 1
+        assert messages[0].msg_type == MessageType.ERROR
+        assert "mismatch" in messages[0].error.lower()
+
+    def test_complete_message_has_metadata(self, sample_images):
+        original, prediction = sample_images
+        config = StreamConfig(
+            procedure="orthognathic",
+            intensity=70.0,
+            n_preview_frames=1,
+        )
+        session = StreamSession(config=config)
+        messages = session.generate_preview_frames(original, prediction)
+        complete = messages[-1]
+        assert complete.metadata["procedure"] == "orthognathic"
+        assert complete.metadata["intensity"] == 70.0
+
+    def test_make_progress_message(self):
+        session = StreamSession()
+        msg = session.make_progress_message(0.5, "inference", "Running diffusion")
+        assert msg.msg_type == MessageType.PROGRESS
+        assert msg.progress == 0.5
+        assert msg.stage == "inference"
+        assert msg.session_id == session.session_id
+
+    def test_make_error_message(self):
+        session = StreamSession()
+        msg = session.make_error_message("GPU out of memory")
+        assert msg.msg_type == MessageType.ERROR
+        assert msg.error == "GPU out of memory"


### PR DESCRIPTION
## Summary
- Adds `landmarkdiff/streaming.py` with typed WebSocket message protocol
- `StreamSession` generates progressive alpha-blended preview frames
- Frames encoded as base64 JPEG with configurable quality
- Message types: connect, start, frame, progress, complete, error, cancel
- `StreamConfig` with procedure, intensity, preview count, quality settings
- Supports session cancellation mid-stream
- 24 tests covering protocol, encoding, session, and edge cases

Closes #146

## Test plan
- [x] All 24 tests pass locally
- [ ] CI lint passes
- [ ] CI type-check passes
- [ ] CI tests pass on 3.10/3.11/3.12