### PR TITLE
Add token bucket rate limiter for API endpoints

### DIFF
--- a/landmarkdiff/rate_limit.py
+++ b/landmarkdiff/rate_limit.py
@@ -1,0 +1,185 @@
+"""Token bucket rate limiter for API endpoints.
+
+Provides configurable per-client rate limiting with burst support.
+Suitable for use as FastAPI middleware or standalone.
+
+Usage:
+    from landmarkdiff.rate_limit import RateLimiter
+
+    limiter = RateLimiter(rate=10.0, burst=20)
+    if limiter.allow("client_ip"):
+        handle_request()
+    else:
+        return 429, "Too Many Requests"
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TokenBucket:
+    """Token bucket for a single client.
+
+    Tokens refill at a constant rate up to the burst capacity.
+    Each request consumes one token.
+
+    Args:
+        rate: Tokens added per second.
+        burst: Maximum token capacity.
+    """
+
+    rate: float
+    burst: int
+    tokens: float = 0.0
+    last_refill: float = field(default_factory=time.monotonic)
+
+    def __post_init__(self) -> None:
+        self.tokens = float(self.burst)
+
+    def refill(self) -> None:
+        """Refill tokens based on elapsed time."""
+        now = time.monotonic()
+        elapsed = now - self.last_refill
+        self.tokens = min(self.burst, self.tokens + elapsed * self.rate)
+        self.last_refill = now
+
+    def consume(self, n: int = 1) -> bool:
+        """Try to consume n tokens.
+
+        Args:
+            n: Number of tokens to consume.
+
+        Returns:
+            True if tokens were available and consumed.
+        """
+        self.refill()
+        if self.tokens >= n:
+            self.tokens -= n
+            return True
+        return False
+
+    @property
+    def available(self) -> int:
+        """Number of tokens currently available (after refill)."""
+        self.refill()
+        return int(self.tokens)
+
+
+class RateLimiter:
+    """Per-client token bucket rate limiter.
+
+    Each client (identified by a string key such as IP address or
+    API key) gets an independent token bucket with the configured
+    rate and burst capacity.
+
+    Args:
+        rate: Requests per second allowed per client.
+        burst: Maximum burst size (bucket capacity).
+        cleanup_interval: Seconds between stale bucket cleanup.
+    """
+
+    def __init__(
+        self,
+        rate: float = 10.0,
+        burst: int = 20,
+        cleanup_interval: float = 300.0,
+    ) -> None:
+        if rate <= 0:
+            raise ValueError(f"rate must be positive, got {rate}")
+        if burst < 1:
+            raise ValueError(f"burst must be >= 1, got {burst}")
+
+        self.rate = rate
+        self.burst = burst
+        self.cleanup_interval = cleanup_interval
+        self._buckets: dict[str, TokenBucket] = {}
+        self._last_cleanup = time.monotonic()
+        self._total_allowed = 0
+        self._total_denied = 0
+
+    def allow(self, client_id: str, cost: int = 1) -> bool:
+        """Check if a request from the given client is allowed.
+
+        Args:
+            client_id: Client identifier (IP, API key, etc.).
+            cost: Number of tokens this request costs.
+
+        Returns:
+            True if the request is allowed, False if rate limited.
+        """
+        self._maybe_cleanup()
+
+        bucket = self._buckets.get(client_id)
+        if bucket is None:
+            bucket = TokenBucket(rate=self.rate, burst=self.burst)
+            self._buckets[client_id] = bucket
+
+        if bucket.consume(cost):
+            self._total_allowed += 1
+            return True
+
+        self._total_denied += 1
+        logger.debug("Rate limited: %s", client_id)
+        return False
+
+    def remaining(self, client_id: str) -> int:
+        """Get remaining tokens for a client.
+
+        Args:
+            client_id: Client identifier.
+
+        Returns:
+            Number of available tokens, or burst if client is new.
+        """
+        bucket = self._buckets.get(client_id)
+        if bucket is None:
+            return self.burst
+        return bucket.available
+
+    def reset(self, client_id: str) -> None:
+        """Reset a client's token bucket to full capacity.
+
+        Args:
+            client_id: Client identifier to reset.
+        """
+        if client_id in self._buckets:
+            del self._buckets[client_id]
+
+    def _maybe_cleanup(self) -> None:
+        """Remove stale buckets that have been fully refilled."""
+        now = time.monotonic()
+        if now - self._last_cleanup < self.cleanup_interval:
+            return
+
+        stale = [cid for cid, bucket in self._buckets.items() if bucket.available >= self.burst]
+        for cid in stale:
+            del self._buckets[cid]
+
+        if stale:
+            logger.debug("Cleaned up %d stale rate limit buckets", len(stale))
+        self._last_cleanup = now
+
+    @property
+    def active_clients(self) -> int:
+        """Number of clients with active rate limit buckets."""
+        return len(self._buckets)
+
+    @property
+    def stats(self) -> dict[str, Any]:
+        """Rate limiter statistics."""
+        total = self._total_allowed + self._total_denied
+        return {
+            "rate": self.rate,
+            "burst": self.burst,
+            "active_clients": self.active_clients,
+            "total_allowed": self._total_allowed,
+            "total_denied": self._total_denied,
+            "deny_rate": round(self._total_denied / total, 4) if total > 0 else 0.0,
+        }

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,174 @@
+"""Tests for token bucket rate limiter."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from landmarkdiff.rate_limit import RateLimiter, TokenBucket
+
+
+class TestTokenBucket:
+    def test_initial_tokens_equal_burst(self):
+        bucket = TokenBucket(rate=10.0, burst=20)
+        assert bucket.tokens == 20.0
+
+    def test_consume_reduces_tokens(self):
+        bucket = TokenBucket(rate=10.0, burst=5)
+        assert bucket.consume() is True
+        assert bucket.tokens < 5.0
+
+    def test_consume_fails_when_empty(self):
+        bucket = TokenBucket(rate=1.0, burst=2)
+        assert bucket.consume(2) is True
+        assert bucket.consume() is False
+
+    def test_refill_adds_tokens(self):
+        bucket = TokenBucket(rate=1000.0, burst=100)
+        bucket.tokens = 0
+        bucket.last_refill = time.monotonic() - 0.1  # 100ms ago
+        bucket.refill()
+        assert bucket.tokens >= 90  # ~100 tokens at 1000/s in 0.1s
+
+    def test_refill_caps_at_burst(self):
+        bucket = TokenBucket(rate=1000.0, burst=10)
+        bucket.tokens = 5
+        bucket.last_refill = time.monotonic() - 1.0  # 1s ago
+        bucket.refill()
+        assert bucket.tokens == 10  # capped at burst
+
+    def test_available_after_refill(self):
+        bucket = TokenBucket(rate=100.0, burst=50)
+        bucket.tokens = 0
+        bucket.last_refill = time.monotonic() - 0.5
+        assert bucket.available >= 45  # ~50 tokens at 100/s in 0.5s
+
+
+class TestRateLimiterInit:
+    def test_default_config(self):
+        limiter = RateLimiter()
+        assert limiter.rate == 10.0
+        assert limiter.burst == 20
+
+    def test_custom_config(self):
+        limiter = RateLimiter(rate=5.0, burst=10)
+        assert limiter.rate == 5.0
+        assert limiter.burst == 10
+
+    def test_invalid_rate(self):
+        with pytest.raises(ValueError, match="rate must be positive"):
+            RateLimiter(rate=0)
+
+    def test_invalid_burst(self):
+        with pytest.raises(ValueError, match="burst must be >= 1"):
+            RateLimiter(burst=0)
+
+
+class TestRateLimiterAllow:
+    def test_allows_within_burst(self):
+        limiter = RateLimiter(rate=1.0, burst=5)
+        for _ in range(5):
+            assert limiter.allow("client1") is True
+
+    def test_denies_after_burst_exhausted(self):
+        limiter = RateLimiter(rate=1.0, burst=3)
+        for _ in range(3):
+            limiter.allow("client1")
+        assert limiter.allow("client1") is False
+
+    def test_independent_clients(self):
+        limiter = RateLimiter(rate=1.0, burst=2)
+        assert limiter.allow("a") is True
+        assert limiter.allow("a") is True
+        assert limiter.allow("a") is False  # "a" exhausted
+        assert limiter.allow("b") is True  # "b" independent
+
+    def test_custom_cost(self):
+        limiter = RateLimiter(rate=1.0, burst=10)
+        assert limiter.allow("client", cost=8) is True
+        assert limiter.allow("client", cost=5) is False  # only ~2 left
+
+    def test_tokens_refill_over_time(self):
+        limiter = RateLimiter(rate=1000.0, burst=5)
+        # Exhaust tokens
+        for _ in range(5):
+            limiter.allow("client")
+        assert limiter.allow("client") is False
+
+        # Manually age the bucket
+        limiter._buckets["client"].last_refill = time.monotonic() - 0.1
+        assert limiter.allow("client") is True  # refilled
+
+
+class TestRateLimiterRemaining:
+    def test_new_client_has_full_burst(self):
+        limiter = RateLimiter(rate=10.0, burst=20)
+        assert limiter.remaining("new_client") == 20
+
+    def test_remaining_decreases_after_allow(self):
+        limiter = RateLimiter(rate=1.0, burst=10)
+        limiter.allow("client")
+        assert limiter.remaining("client") < 10
+
+
+class TestRateLimiterReset:
+    def test_reset_restores_burst(self):
+        limiter = RateLimiter(rate=1.0, burst=3)
+        for _ in range(3):
+            limiter.allow("client")
+        assert limiter.allow("client") is False
+        limiter.reset("client")
+        assert limiter.allow("client") is True
+
+    def test_reset_nonexistent_is_noop(self):
+        limiter = RateLimiter()
+        limiter.reset("nonexistent")  # should not raise
+
+
+class TestRateLimiterStats:
+    def test_initial_stats(self):
+        limiter = RateLimiter(rate=5.0, burst=10)
+        stats = limiter.stats
+        assert stats["rate"] == 5.0
+        assert stats["burst"] == 10
+        assert stats["total_allowed"] == 0
+        assert stats["total_denied"] == 0
+        assert stats["deny_rate"] == 0.0
+
+    def test_stats_tracking(self):
+        limiter = RateLimiter(rate=1.0, burst=2)
+        limiter.allow("client")
+        limiter.allow("client")
+        limiter.allow("client")  # denied
+        stats = limiter.stats
+        assert stats["total_allowed"] == 2
+        assert stats["total_denied"] == 1
+        assert stats["deny_rate"] == pytest.approx(1 / 3, abs=0.01)
+
+    def test_active_clients(self):
+        limiter = RateLimiter(rate=10.0, burst=20)
+        limiter.allow("a")
+        limiter.allow("b")
+        limiter.allow("c")
+        assert limiter.active_clients == 3
+
+
+class TestRateLimiterCleanup:
+    def test_cleanup_removes_full_buckets(self):
+        limiter = RateLimiter(rate=10.0, burst=5, cleanup_interval=0)
+        limiter.allow("client")
+        # Manually fill the bucket
+        limiter._buckets["client"].tokens = 5
+        # Trigger cleanup
+        limiter._last_cleanup = 0
+        limiter.allow("other")  # triggers _maybe_cleanup
+        assert "client" not in limiter._buckets
+
+    def test_cleanup_keeps_active_buckets(self):
+        limiter = RateLimiter(rate=1.0, burst=5, cleanup_interval=0)
+        for _ in range(5):
+            limiter.allow("active")
+        limiter._last_cleanup = 0
+        limiter.allow("other")
+        assert "active" in limiter._buckets  # still depleted


### PR DESCRIPTION
## Summary
- Adds `RateLimiter` in `landmarkdiff/rate_limit.py` using token bucket algorithm
- Per-client independent rate limiting with configurable rate and burst
- Token refill based on elapsed time, automatic stale bucket cleanup
- Allow/deny statistics tracking with deny rate metric
- 24 tests covering bucket mechanics, client isolation, cleanup, and stats

## Test plan
- [x] All 24 tests pass locally
- [ ] CI lint passes
- [ ] CI type-check passes
- [ ] CI tests pass on 3.10/3.11/3.12