### PR TITLE
Replace em dashes with standard punctuation across all docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,18 +29,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 26 new utility scripts synced from upstream (evaluation, visualization, paper figure generation)
 - GitHub wiki expanded to 15 pages (procedure guides, training walkthrough, evaluation reference)
 - Real demo faces in HF Space replacing placeholder images
-- `build_qualitative_grid.py` -- multi-procedure qualitative comparison grid
-- `generate_comparison_figure.py` -- side-by-side method comparison figure
-- `landmark_accuracy_heatmap.py` -- per-landmark error heatmap for paper
-- `visualize_attention.py` -- ControlNet cross-attention map visualization
-- `visualize_latent_space.py` -- UMAP/PCA projection of latent codes by procedure
-- `progressive_denoising.py` -- denoising trajectory strip for supplementary
-- `intensity_sweep.py` -- full intensity sweep grid (0-100%) for all procedures
+- `build_qualitative_grid.py`: multi-procedure qualitative comparison grid
+- `generate_comparison_figure.py`: side-by-side method comparison figure
+- `landmark_accuracy_heatmap.py`: per-landmark error heatmap for paper
+- `visualize_attention.py`: ControlNet cross-attention map visualization
+- `visualize_latent_space.py`: UMAP/PCA projection of latent codes by procedure
+- `progressive_denoising.py`: denoising trajectory strip for supplementary
+- `intensity_sweep.py`: full intensity sweep grid (0-100%) for all procedures
 
 ### Changed
 - bf16 is now the default training precision (was fp32)
 - Loss weight tuning: landmark weight 0.1, identity weight 0.05, perceptual weight 0.1 (defaults locked)
-- HF Space UI simplified -- single-panel layout, procedure selector cleaned up
+- HF Space UI simplified: single-panel layout, procedure selector cleaned up
 - CI workflow updated: pinned action versions, pip caching, per-job concurrency control
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,9 +215,9 @@ class TestFrobnicate:
 
 CI runs on every push to `main` and on every pull request. It checks:
 
-1. **Lint** -- `ruff check` and `ruff format --check`
-2. **Type check** -- `mypy`
-3. **Tests** -- `pytest` on Python 3.10, 3.11, and 3.12
+1. **Lint:** `ruff check` and `ruff format --check`
+2. **Type check:** `mypy`
+3. **Tests:** `pytest` on Python 3.10, 3.11, and 3.12
 
 All three must pass before a PR can be merged.
 
@@ -298,7 +298,7 @@ LandmarkDiff currently supports six surgical procedures. Each one is defined as 
 | `brow_lift`      | Forehead and brow elevation                | 18             | 25.0                   |
 | `mentoplasty`    | Chin augmentation / reduction              | 8              | 25.0                   |
 
-Both `brow_lift` and `mentoplasty` were contributed by community members -- see PRs [#35](https://github.com/dreamlessx/LandmarkDiff-public/pull/35) and [#36](https://github.com/dreamlessx/LandmarkDiff-public/pull/36).
+Both `brow_lift` and `mentoplasty` were contributed by community members; see PRs [#35](https://github.com/dreamlessx/LandmarkDiff-public/pull/35) and [#36](https://github.com/dreamlessx/LandmarkDiff-public/pull/36).
 
 ---
 
@@ -432,7 +432,7 @@ To add a new clinical flag:
 1. **Add the field** to the `ClinicalFlags` dataclass in `landmarkdiff/clinical.py`.
 2. **Implement the modifier** as a function in the same module. The modifier should adjust either the deformation handles, the mask, or the influence radii depending on the condition.
 3. **Wire it in.** Call your modifier from `apply_procedure_preset()` in `manipulation.py` (for deformation changes) or from the mask generation code in `masking.py` (for mask changes).
-4. **Add the flag to the Gradio demo** in `scripts/app.py` -- typically as a checkbox in Tab 1.
+4. **Add the flag to the Gradio demo** in `scripts/app.py`, typically as a checkbox in Tab 1.
 5. **Write tests** that verify the flag actually modifies the output relative to the unflagged case.
 6. **Document** the clinical rationale. Include references to the medical literature if possible.
 
@@ -448,9 +448,9 @@ The current pipeline operates on single 2D images. Lifting to 3D requires fittin
 
 Areas where contributions are welcome:
 
-- **FLAME integration** -- fitting [FLAME](https://flame.is.tue.mpg.de/) parameters from MediaPipe landmarks or dense face alignment, producing a textured 3D mesh from a single frame or short video.
-- **Neural implicit representations** -- NeRF or 3D Gaussian Splatting (3DGS) approaches for head reconstruction from a phone video scan. Particularly useful: methods that work with sparse views (10-30 frames) and reconstruct in under a minute.
-- **Mesh-landmark correspondence** -- mapping the 478 MediaPipe landmarks to FLAME mesh vertices so that existing 2D procedure presets can be projected into 3D displacement vectors.
+- **FLAME integration:** fitting [FLAME](https://flame.is.tue.mpg.de/) parameters from MediaPipe landmarks or dense face alignment, producing a textured 3D mesh from a single frame or short video.
+- **Neural implicit representations:** NeRF or 3D Gaussian Splatting (3DGS) approaches for head reconstruction from a phone video scan. Particularly useful: methods that work with sparse views (10-30 frames) and reconstruct in under a minute.
+- **Mesh-landmark correspondence:** mapping the 478 MediaPipe landmarks to FLAME mesh vertices so that existing 2D procedure presets can be projected into 3D displacement vectors.
 
 If you have experience with DECA, EMOCA, PanoHead, or similar, your expertise is directly applicable.
 
@@ -458,26 +458,26 @@ If you have experience with DECA, EMOCA, PanoHead, or similar, your expertise is
 
 Once a deformed 3D model exists, patients need to view it interactively.
 
-- **WebGL/three.js viewer** -- a browser-based viewer that renders the reconstructed face from arbitrary viewpoints, with controls for rotating, zooming, and comparing pre/post deformation side by side.
-- **Gradio 3D integration** -- extending the existing Gradio demo (`scripts/app.py`) to embed a 3D model viewer tab alongside the current 2D outputs.
-- **Texture and lighting** -- realistic relighting and texture transfer so the 3D preview looks natural rather than synthetic.
+- **WebGL/three.js viewer:** a browser-based viewer that renders the reconstructed face from arbitrary viewpoints, with controls for rotating, zooming, and comparing pre/post deformation side by side.
+- **Gradio 3D integration:** extending the existing Gradio demo (`scripts/app.py`) to embed a 3D model viewer tab alongside the current 2D outputs.
+- **Texture and lighting:** realistic relighting and texture transfer so the 3D preview looks natural rather than synthetic.
 
 ### Mobile capture pipeline
 
 The phone-scan capture workflow is a critical UX piece.
 
-- **Frame selection** -- given a video of a patient rotating their head, select the N most informative frames (coverage, sharpness, landmark confidence) for reconstruction.
-- **Real-time guidance** -- lightweight on-device feedback telling the patient to turn left, tilt up, etc., ensuring sufficient angular coverage.
-- **Landmark tracking across frames** -- temporally consistent MediaPipe tracking with outlier rejection and smoothing.
+- **Frame selection:** given a video of a patient rotating their head, select the N most informative frames (coverage, sharpness, landmark confidence) for reconstruction.
+- **Real-time guidance:** lightweight on-device feedback telling the patient to turn left, tilt up, etc., ensuring sufficient angular coverage.
+- **Landmark tracking across frames:** temporally consistent MediaPipe tracking with outlier rejection and smoothing.
 
 ### 3D evaluation metrics
 
 We will need metrics that go beyond 2D FID and LPIPS:
 
-- **3D landmark error** -- Euclidean distance between predicted and ground-truth 3D landmark positions.
-- **Mesh surface distance** -- Chamfer distance or Hausdorff distance between reconstructed and reference meshes.
-- **Multi-view consistency** -- measuring whether the deformed model renders consistently across viewpoints (no view-dependent artifacts).
-- **Identity preservation in 3D** -- extending the current ArcFace identity score to aggregate across multiple rendered views.
+- **3D landmark error:** Euclidean distance between predicted and ground-truth 3D landmark positions.
+- **Mesh surface distance:** Chamfer distance or Hausdorff distance between reconstructed and reference meshes.
+- **Multi-view consistency:** measuring whether the deformed model renders consistently across viewpoints (no view-dependent artifacts).
+- **Identity preservation in 3D:** extending the current ArcFace identity score to aggregate across multiple rendered views.
 
 If any of these areas interest you, open an issue tagged `enhancement` describing what you want to work on, and we can discuss the approach before you start coding.
 

--- a/MODEL_ZOO.md
+++ b/MODEL_ZOO.md
@@ -59,7 +59,7 @@ python scripts/train_controlnet.py --data_dir data/synthetic_pairs/ --output_dir
 
 ## Planned Models
 
-The following models are on the roadmap as LandmarkDiff moves toward a 3D-native pipeline (phone video scan to interactive 3D surgical preview). None of these are available yet -- this section previews what is coming.
+The following models are on the roadmap as LandmarkDiff moves toward a 3D-native pipeline (phone video scan to interactive 3D surgical preview). None of these are available yet; this section previews what is coming.
 
 | Model | Approach | Purpose | Status |
 |-------|----------|---------|--------|

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ Photorealistic facial surgery outcome prediction from a single photo, powered by
 <td width="50%" valign="top">
 
 **Input & Output**
-- Single 2D photo -- any clinical photo or phone selfie
+- Single 2D photo: any clinical photo or phone selfie
 - Photorealistic post-op prediction
-- Just a phone -- no depth sensors, no clinical equipment
+- Just a phone, no depth sensors, no clinical equipment
 
 </td>
 <td width="50%" valign="top">
 
 **Capabilities**
-- **6 procedures** -- rhinoplasty, blepharoplasty, rhytidectomy, orthognathic, brow lift, mentoplasty
-- **4 inference modes** -- TPS (CPU), img2img, ControlNet, ControlNet+IP
-- **5 clinical flags** -- vitiligo, Bell's palsy, keloid, Ehlers-Danlos, Fitzpatrick-stratified eval
+- **6 procedures:** rhinoplasty, blepharoplasty, rhytidectomy, orthognathic, brow lift, mentoplasty
+- **4 inference modes:** TPS (CPU), img2img, ControlNet, ControlNet+IP
+- **5 clinical flags:** vitiligo, Bell's palsy, keloid, Ehlers-Danlos, Fitzpatrick-stratified eval
 
 </td>
 </tr>
@@ -47,7 +47,7 @@ Photorealistic facial surgery outcome prediction from a single photo, powered by
 
 ### Where We're Headed
 
-The 2D pipeline ships now and works well. The end goal is full 3D: you hold up your phone, slowly rotate your head, and we reconstruct a 3D face model from that video alone. Surgical deformations then happen in 3D space -- anatomically grounded, not pixel-level warping -- and you get an interactive model you can rotate to see the predicted result from any angle. No depth sensors, no clinical scanning rigs. Just a phone camera and a short video. See the [Roadmap](#roadmap) for details on each step.
+The 2D pipeline ships now and works well. The end goal is full 3D: you hold up your phone, slowly rotate your head, and we reconstruct a 3D face model from that video alone. Surgical deformations then happen in 3D space (anatomically grounded, not pixel-level warping) and you get an interactive model you can rotate to see the predicted result from any angle. No depth sensors, no clinical scanning rigs. Just a phone camera and a short video. See the [Roadmap](#roadmap) for details on each step.
 
 LandmarkDiff extracts MediaPipe's 478-point face mesh from the input photo, applies procedure-specific Gaussian RBF deformations calibrated from anthropometric surgical data, renders the deformed mesh as a tessellation wireframe, and feeds that wireframe into a ControlNet-conditioned Stable Diffusion 1.5 backbone to synthesize the predicted face. The output is composited back onto the original image using Laplacian pyramid blending with feathered surgical masks, then refined through neural face restoration and identity verification.
 
@@ -56,7 +56,7 @@ LandmarkDiff extracts MediaPipe's 478-point face mesh from the input photo, appl
 <p align="center">
   <img src="demos/demo_pipeline_0.png" alt="LandmarkDiff pipeline" width="90%">
   <br>
-  <em>Full pipeline: input photo -- landmark extraction -- mesh deformation -- ControlNet synthesis -- compositing</em>
+  <em>Full pipeline: input photo, landmark extraction, mesh deformation, ControlNet synthesis, compositing</em>
 </p>
 
 ### Try the Live Demo
@@ -116,21 +116,21 @@ python scripts/run_inference.py photo.jpg --procedure rhinoplasty --intensity 60
 
 ## Features
 
-- **Single-photo input** -- works from any 2D clinical photograph or phone selfie, no 3D scanning hardware needed
-- **6 surgical procedure presets** -- rhinoplasty, blepharoplasty, rhytidectomy, orthognathic surgery, brow lift, mentoplasty (extensible to custom procedures)
-- **4 inference modes** -- TPS (instant CPU), img2img, ControlNet, and ControlNet+IP-Adapter with configurable quality/speed tradeoffs
-- **MediaPipe 478-point face mesh** -- anatomically grounded landmark extraction for precise deformation control
-- **Gaussian RBF deformation engine** -- smooth, spatially weighted displacements calibrated from anthropometric surgical data
-- **ControlNet-conditioned generation** -- photorealistic texture synthesis via Stable Diffusion 1.5 with wireframe conditioning
-- **Neural post-processing** -- CodeFormer face restoration, Real-ESRGAN upscaling, LAB histogram matching, Laplacian pyramid blending
-- **ArcFace identity verification** -- ensures the predicted face preserves patient identity (cosine similarity check)
-- **Clinical edge-case handling** -- built-in support for vitiligo, Bell's palsy, keloid-prone skin, and Ehlers-Danlos syndrome
-- **Fitzpatrick-stratified evaluation** -- all metrics (FID, LPIPS, SSIM, NME, identity) broken down by skin type I through VI
-- **Intensity slider (0-100%)** -- preview subtle through aggressive versions of any procedure
-- **Gradio web demo** -- 5-tab interface with single procedure, multi-procedure comparison, intensity sweep, face analysis, and multi-angle capture
-- **HPC training pipeline** -- SLURM scripts with preemption checkpointing, DDP multi-GPU, curriculum training configs
-- **Docker and Apptainer support** -- CPU and GPU container images for reproducible deployment
-- **PEP 561 typed package** -- ships with `py.typed` marker for downstream type checking
+- **Single-photo input:** works from any 2D clinical photograph or phone selfie, no 3D scanning hardware needed
+- **6 surgical procedure presets:** rhinoplasty, blepharoplasty, rhytidectomy, orthognathic surgery, brow lift, mentoplasty (extensible to custom procedures)
+- **4 inference modes:** TPS (instant CPU), img2img, ControlNet, and ControlNet+IP-Adapter with configurable quality/speed tradeoffs
+- **MediaPipe 478-point face mesh:** anatomically grounded landmark extraction for precise deformation control
+- **Gaussian RBF deformation engine:** smooth, spatially weighted displacements calibrated from anthropometric surgical data
+- **ControlNet-conditioned generation:** photorealistic texture synthesis via Stable Diffusion 1.5 with wireframe conditioning
+- **Neural post-processing:** CodeFormer face restoration, Real-ESRGAN upscaling, LAB histogram matching, Laplacian pyramid blending
+- **ArcFace identity verification:** ensures the predicted face preserves patient identity (cosine similarity check)
+- **Clinical edge-case handling:** built-in support for vitiligo, Bell's palsy, keloid-prone skin, and Ehlers-Danlos syndrome
+- **Fitzpatrick-stratified evaluation:** all metrics (FID, LPIPS, SSIM, NME, identity) broken down by skin type I through VI
+- **Intensity slider (0-100%):** preview subtle through aggressive versions of any procedure
+- **Gradio web demo:** 5-tab interface with single procedure, multi-procedure comparison, intensity sweep, face analysis, and multi-angle capture
+- **HPC training pipeline:** SLURM scripts with preemption checkpointing, DDP multi-GPU, curriculum training configs
+- **Docker and Apptainer support:** CPU and GPU container images for reproducible deployment
+- **PEP 561 typed package:** ships with `py.typed` marker for downstream type checking
 
 ---
 
@@ -140,35 +140,35 @@ python scripts/run_inference.py photo.jpg --procedure rhinoplasty --intensity 60
 
 Facial cosmetic surgery is one of the most common elective procedures worldwide. The American Society of Plastic Surgeons (ASPS) reported [15.6 million cosmetic procedures in the US in 2020](https://www.plasticsurgery.org/news/plastic-surgery-statistics), with rhinoplasty and blepharoplasty consistently ranking among the top 5 surgical procedures. These numbers have only grown since.
 
-The problem is expectation management. Roughly 10--15% of rhinoplasty patients seek revision surgery, and a significant driver is the gap between what patients expected and what they got (Rohrich & Ahmad, "A Practical Approach to Rhinoplasty," *Plastic and Reconstructive Surgery*, 2016). Preoperative visualization directly affects satisfaction -- patients who see a realistic preview report better alignment between expectations and results (Kandathil et al., "Examining Preoperative Expectations and Postoperative Satisfaction in Rhinoplasty Patients," *Facial Plastic Surgery & Aesthetic Medicine*, 2021). Systematic reviews of patient-reported outcomes in rhinoplasty confirm that expectation alignment is a key predictor of satisfaction (Leong & Iglesias, "A systematic review of patient-reported outcome measures in aesthetic and functional rhinoplasty," *Journal of Plastic, Reconstructive & Aesthetic Surgery*, 2016).
+The problem is expectation management. Roughly 10 to 15% of rhinoplasty patients seek revision surgery, and a significant driver is the gap between what patients expected and what they got (Rohrich & Ahmad, "A Practical Approach to Rhinoplasty," *Plastic and Reconstructive Surgery*, 2016). Preoperative visualization directly affects satisfaction; patients who see a realistic preview report better alignment between expectations and results (Kandathil et al., "Examining Preoperative Expectations and Postoperative Satisfaction in Rhinoplasty Patients," *Facial Plastic Surgery & Aesthetic Medicine*, 2021). Systematic reviews of patient-reported outcomes in rhinoplasty confirm that expectation alignment is a key predictor of satisfaction (Leong & Iglesias, "A systematic review of patient-reported outcome measures in aesthetic and functional rhinoplasty," *Journal of Plastic, Reconstructive & Aesthetic Surgery*, 2016).
 
-But here's the catch: the tools that produce good visualizations are expensive, proprietary, or both. Most surgeons -- especially outside wealthy urban practices -- don't have access to them.
+But here's the catch: the tools that produce good visualizations are expensive, proprietary, or both. Most surgeons, especially outside wealthy urban practices, don't have access to them.
 
 ### Existing Tools and Their Limitations
 
 **Tier 1: Clinical 3D Simulation**
 
-- **Canfield Scientific VECTRA** (~$30-100K) -- Dedicated structured-light 3D scanner paired with Mirror simulation software. The gold standard in top-tier practices. Produces accurate surface meshes with Face Sculptor for tissue movement simulation. Requires trained operators, expensive hardware, and in-office capture. Proprietary with no published validation studies on prediction accuracy. [Website](https://www.canfieldsci.com/imaging-systems/vectra-xt-3d-imaging-system/)
-- **Crisalix** (~$200-500/mo) -- Cloud-based 3D simulation from 2D photos. 17 years in market, PE-backed (BID Equity). Supports breast and face procedures. Uses geometric morphing, not AI or diffusion. More accessible than VECTRA, but subscription-based, proprietary, and there's no open evaluation of its fidelity. [Website](https://www.crisalix.com)
-- **AEDIT** ($60/mo consumer) -- Phone-based 3D scanning using 100+ photos via TrueDepth camera. Patented morphing with "100,000 facial recognition points." Covers rhinoplasty, lip filler, brow lift, and Botox simulation. Multiple patents on 3D reconstruction from phone input. Consumer-first approach, iOS only. [Website](https://aedit.com/aeditor-app)
+- **Canfield Scientific VECTRA** (~$30-100K): Dedicated structured-light 3D scanner paired with Mirror simulation software. The gold standard in top-tier practices. Produces accurate surface meshes with Face Sculptor for tissue movement simulation. Requires trained operators, expensive hardware, and in-office capture. Proprietary with no published validation studies on prediction accuracy. [Website](https://www.canfieldsci.com/imaging-systems/vectra-xt-3d-imaging-system/)
+- **Crisalix** (~$200-500/mo): Cloud-based 3D simulation from 2D photos. 17 years in market, PE-backed (BID Equity). Supports breast and face procedures. Uses geometric morphing, not AI or diffusion. More accessible than VECTRA, but subscription-based, proprietary, and there's no open evaluation of its fidelity. [Website](https://www.crisalix.com)
+- **AEDIT** ($60/mo consumer): Phone-based 3D scanning using 100+ photos via TrueDepth camera. Patented morphing with "100,000 facial recognition points." Covers rhinoplasty, lip filler, brow lift, and Botox simulation. Multiple patents on 3D reconstruction from phone input. Consumer-first approach, iOS only. [Website](https://aedit.com/aeditor-app)
 
 **Tier 2: Practice Management + Lite Simulation**
 
-- **FaceTouchUp** (~$50-100/mo) -- 2D morphing tool with AR overlay. Affordable and quick for consultations, but results look like warped photographs because that's exactly what they are -- geometric transforms with no understanding of how skin, light, or tissue actually behave. [Website](https://www.facetouchup.com)
-- **TouchMD / Symplast / Consentz** -- EMR and practice management platforms with basic photo ghosting or overlay features, not true surgical simulation.
+- **FaceTouchUp** (~$50-100/mo): 2D morphing tool with AR overlay. Affordable and quick for consultations, but results look like warped photographs because that's exactly what they are, geometric transforms with no understanding of how skin, light, or tissue actually behave. [Website](https://www.facetouchup.com)
+- **TouchMD / Symplast / Consentz:** EMR and practice management platforms with basic photo ghosting or overlay features, not true surgical simulation.
 
 **Tier 3: Consumer Beauty Tech**
 
-- **Perfect Corp** -- AI-powered face reshape for beauty and med spa applications. Focused on fillers and Botox visualization, not structural surgical prediction. [Website](https://www.perfectcorp.com)
-- **GlamAR** -- Virtual try-on API for beauty brands. Cosmetics overlay layer, not surgical simulation. [Website](https://www.glamar.io)
+- **Perfect Corp:** AI-powered face reshape for beauty and med spa applications. Focused on fillers and Botox visualization, not structural surgical prediction. [Website](https://www.perfectcorp.com)
+- **GlamAR:** Virtual try-on API for beauty brands. Cosmetics overlay layer, not surgical simulation. [Website](https://www.glamar.io)
 
 **Academic approaches:**
 
 Most recent academic work on face manipulation focuses on generic editing (make someone look older, change their expression, swap identities) rather than surgery-specific prediction. A few notable examples:
 
-- **DiscoFaceGAN** (Deng et al., CVPR 2020) -- Disentangled controllable face generation using 3DMM coefficients. Powerful for attribute editing, but designed for general-purpose face manipulation, not surgical planning. No procedure-specific deformation models.
-- **FaceShifter** (Li et al., 2019) -- High-fidelity face swapping with occlusion awareness. Impressive identity transfer, but the goal is swapping one person's face onto another, not simulating what a surgical procedure would do to the same person.
-- **DiffFace** (Kim et al., 2022) -- Diffusion-based face swapping with facial guidance. Shows the potential of diffusion models for face manipulation, but targets identity transfer, not surgical outcome prediction.
+- **DiscoFaceGAN** (Deng et al., CVPR 2020): Disentangled controllable face generation using 3DMM coefficients. Powerful for attribute editing, but designed for general-purpose face manipulation, not surgical planning. No procedure-specific deformation models.
+- **FaceShifter** (Li et al., 2019): High-fidelity face swapping with occlusion awareness. Impressive identity transfer, but the goal is swapping one person's face onto another, not simulating what a surgical procedure would do to the same person.
+- **DiffFace** (Kim et al., 2022): Diffusion-based face swapping with facial guidance. Shows the potential of diffusion models for face manipulation, but targets identity transfer, not surgical outcome prediction.
 
 The common thread: none of the commercial tools use diffusion models (all rely on geometric warping or morphing), almost none of the academic work uses real surgical data to drive deformations, none evaluates fairness across skin tones, and none handles clinical edge cases like Bell's palsy or keloid-prone skin.
 
@@ -186,7 +186,7 @@ The common thread: none of the commercial tools use diffusion models (all rely o
 
 ### What Makes LandmarkDiff Different
 
-LandmarkDiff is not trying to compete with VECTRA on 3D accuracy -- we're solving a different problem. We want to make surgery visualization accessible to any surgeon with a phone and any patient who walks into a consultation, while being honest about what the tool can and can't do.
+LandmarkDiff is not trying to compete with VECTRA on 3D accuracy; we're solving a different problem. We want to make surgery visualization accessible to any surgeon with a phone and any patient who walks into a consultation, while being honest about what the tool can and can't do.
 
 **No existing tool uses diffusion models.** Every competitor in the comparison table above relies on geometric warping or morphing. LandmarkDiff is the first published system to apply ControlNet-conditioned latent diffusion to surgical outcome prediction, producing photorealistic texture synthesis rather than geometric pixel manipulation. Combined with open-source access, published research, and Fitzpatrick-stratified fairness evaluation, this positions LandmarkDiff as both the most technically advanced and most transparent surgical visualization system available.
 
@@ -195,9 +195,9 @@ Concretely:
 - **Open source (MIT license).** Unlike every commercial tool listed above, you can inspect, modify, and extend the code. If you don't trust the output, you can trace exactly how it was generated.
 - **Single 2D photo input.** No $50K+ hardware, no multi-view capture rigs. A standard clinical photograph or phone selfie is enough.
 - **Anatomically grounded deformations.** Procedure-specific landmark displacements are fitted from real surgical data (pre/post pairs), not hand-tuned or based on generic face editing semantics.
-- **Diffusion-based photorealism.** ControlNet-guided Stable Diffusion produces realistic skin texture, lighting, and shadows -- not geometric morphs.
+- **Diffusion-based photorealism.** ControlNet-guided Stable Diffusion produces realistic skin texture, lighting, and shadows, not geometric morphs.
 - **Clinical edge-case handling.** Built-in flags and modified behavior for vitiligo, Bell's palsy, keloid-prone skin, and Ehlers-Danlos syndrome.
-- **Fitzpatrick-stratified fairness evaluation.** All metrics are broken down by Fitzpatrick skin type (I--VI) to catch and prevent performance disparities across skin tones.
+- **Fitzpatrick-stratified fairness evaluation.** All metrics are broken down by Fitzpatrick skin type (I through VI) to catch and prevent performance disparities across skin tones.
 - **Roadmap toward 3D.** We're working on phone-video-to-3D reconstruction to eventually provide accessible 3D visualization without Vectra-class hardware.
 
 **Honest limitations:** We don't have prospective clinical validation yet (that's planned). Our deformation model is calibrated from a limited dataset. We currently produce 2D output, not 3D. And diffusion models can hallucinate details, so outputs should always be reviewed by a clinician before showing to patients. This is a research tool, not a medical device. The comparison above reflects publicly available information as of March 2026. Commercial tools may have undisclosed technical capabilities.
@@ -205,9 +205,9 @@ Concretely:
 ### References
 
 1. American Society of Plastic Surgeons. [2020 Plastic Surgery Statistics Report](https://www.plasticsurgery.org/news/plastic-surgery-statistics). ASPS, 2021.
-2. Rohrich RJ, Ahmad J. "A Practical Approach to Rhinoplasty." *Plastic and Reconstructive Surgery*. 2016;137(4):725e--746e.
-3. Kandathil CK, et al. "Examining Preoperative Expectations and Postoperative Satisfaction in Rhinoplasty Patients: A Single-Center Study." *Facial Plastic Surgery & Aesthetic Medicine*. 2021;23(1):33--38.
-4. Leong SC, Iglesias MA. "A systematic review of patient-reported outcome measures in aesthetic and functional rhinoplasty." *Journal of Plastic, Reconstructive & Aesthetic Surgery*. 2016;69(12):1635--1645.
+2. Rohrich RJ, Ahmad J. "A Practical Approach to Rhinoplasty." *Plastic and Reconstructive Surgery*. 2016;137(4):725e-746e.
+3. Kandathil CK, et al. "Examining Preoperative Expectations and Postoperative Satisfaction in Rhinoplasty Patients: A Single-Center Study." *Facial Plastic Surgery & Aesthetic Medicine*. 2021;23(1):33-38.
+4. Leong SC, Iglesias MA. "A systematic review of patient-reported outcome measures in aesthetic and functional rhinoplasty." *Journal of Plastic, Reconstructive & Aesthetic Surgery*. 2016;69(12):1635-1645.
 5. Deng Y, et al. "Disentangled and Controllable Face Image Generation via 3D Imitative-Contrastive Learning." CVPR 2020.
 6. Li L, et al. "FaceShifter: Towards High Fidelity And Occlusion Aware Face Swapping." arXiv:1912.13457, 2019.
 7. Kim K, et al. "DiffFace: Diffusion-based Face Swapping with Facial Guidance." arXiv:2212.13344, 2022.
@@ -294,7 +294,7 @@ graph LR
 
     E --> F1 --> F2 --> F3 --> F4 --> F5 --> G
 
-    subgraph future ["Planned -- 3D Extension"]
+    subgraph future ["Planned: 3D Extension"]
         H1["Phone Video<br/>Capture"]:::planned
         H2["FLAME 3D<br/>Reconstruction"]:::planned
         H3["3D Surgical<br/>Deformation"]:::planned
@@ -366,11 +366,11 @@ Six-step refinement:
 ### Pipeline Visualization
 
 <p align="center">
-  <img src="demos/demo_pipeline_0.png" alt="Pipeline demo -- rhinoplasty on diverse faces" width="90%">
+  <img src="demos/demo_pipeline_0.png" alt="Pipeline demo, rhinoplasty on diverse faces" width="90%">
 </p>
 
 <p align="center">
-  <img src="demos/demo_pipeline_1.png" alt="Pipeline demo -- rhinoplasty result" width="90%">
+  <img src="demos/demo_pipeline_1.png" alt="Pipeline demo, rhinoplasty result" width="90%">
 </p>
 
 Each image shows five pipeline stages: **Input | Original Mesh | Manipulated Mesh | Surgical Mask | TPS-warped Result**. These are geometric-only (TPS mode, CPU) outputs; ControlNet photorealistic results will be added after training completes.
@@ -543,8 +543,8 @@ Scores range from 0 to 100, where 90-100 indicates high symmetry, 70-89 mild asy
 
 The demo's **Symmetry Analysis** tab offers two modes:
 
-- **Single photo** -- upload any face photo to get a per-region symmetry breakdown with a color-coded overlay (green/yellow/red).
-- **Pre vs. post comparison** -- upload before and after photos to see how a procedure changed the symmetry profile, with per-region deltas.
+- **Single photo:** upload any face photo to get a per-region symmetry breakdown with a color-coded overlay (green/yellow/red).
+- **Pre vs. post comparison:** upload before and after photos to see how a procedure changed the symmetry profile, with per-region deltas.
 
 Symmetry scores are also computed automatically during inference runs and reported alongside the prediction output.
 
@@ -1006,25 +1006,25 @@ See [docs/ROADMAP.md](docs/ROADMAP.md) for the detailed roadmap with full milest
 - [ ] ControlNet fine-tuning on 50K+ synthetic pairs (in progress)
 - [ ] Populate results tables in paper
 
-### Next (v0.3.0) -- Data-Driven Training
+### Next (v0.3.0): Data-Driven Training
 - [ ] Anatomically constrained displacement sampling with per-procedure variance
 - [ ] ControlNet fine-tuning on 50K+ synthetic pairs (Phase A)
 - [ ] Combined loss training on clinical pairs (Phase B)
 - [ ] Additional procedure presets (otoplasty, genioplasty)
 - [ ] MICCAI 2026 workshop paper and arXiv preprint
 
-### v0.4.0 -- 3D Face Reconstruction
-- [ ] Phone video capture -- rotate head, reconstruct full 3D face from frames
+### v0.4.0: 3D Face Reconstruction
+- [ ] Phone video capture: rotate head, reconstruct full 3D face from frames
 - [ ] FLAME 3D morphable model fitting from monocular video
 - [ ] FLUX.1-dev or SDXL backbone upgrade (higher quality generation at 1024x1024)
 - [ ] IP-Adapter FaceID v2 for stronger identity preservation
 
-### v0.5.0 -- Interactive 3D Surgical Preview
-- [ ] 3D surgical deformation -- procedure-specific warps in 3D space
-- [ ] Interactive 3D preview -- rotate the predicted result from any angle
+### v0.5.0: Interactive 3D Surgical Preview
+- [ ] 3D surgical deformation: procedure-specific warps in 3D space
+- [ ] Interactive 3D preview: rotate the predicted result from any angle
 - [ ] Mobile-optimized capture and preview workflow
 
-### Future (v1.0.0) -- Clinical Validation
+### Future (v1.0.0): Clinical Validation
 - [ ] IRB-approved prospective clinical validation study
 - [ ] Multi-view consistency loss across frontal/profile predictions
 - [ ] Physics-informed tissue simulation (FEM for soft tissue response)

--- a/demos/README.md
+++ b/demos/README.md
@@ -6,8 +6,8 @@ Step-by-step visualization of the LandmarkDiff pipeline stages.
 
 | File | Description |
 |------|-------------|
-| `demo_pipeline_0.png` | Pipeline stages -- Subject 1 |
-| `demo_pipeline_1.png` | Pipeline stages -- Subject 2 |
+| `demo_pipeline_0.png` | Pipeline stages, Subject 1 |
+| `demo_pipeline_1.png` | Pipeline stages, Subject 2 |
 
 Each image shows: **Input | Original Mesh | Manipulated Mesh | Surgical Mask | Result**
 
@@ -19,9 +19,9 @@ All 6 supported procedures applied at intensity 60 using the TPS (CPU-only) pipe
 |------|-------------|
 | `procedure_comparison.png` | Primary grid: original input + all 6 procedure results |
 | `procedure_comparison_all_subjects.png` | All 3 demo faces, before/after for each procedure |
-| `procedure_comparison_0.png` | Before/after grid -- Subject 1 |
-| `procedure_comparison_1.png` | Before/after grid -- Subject 2 |
-| `procedure_comparison_2.png` | Before/after grid -- Subject 3 |
+| `procedure_comparison_0.png` | Before/after grid, Subject 1 |
+| `procedure_comparison_1.png` | Before/after grid, Subject 2 |
+| `procedure_comparison_2.png` | Before/after grid, Subject 3 |
 
 ## Abstract Diagrams
 
@@ -32,7 +32,7 @@ All 6 supported procedures applied at intensity 60 using the TPS (CPU-only) pipe
 
 ## Photorealistic Results
 
-ControlNet-generated photorealistic demos will be added here once model training is complete. The pipeline is fully implemented -- we are currently training on synthetic data and will update this directory with proper results.
+ControlNet-generated photorealistic demos will be added here once model training is complete. The pipeline is fully implemented; we are currently training on synthetic data and will update this directory with proper results.
 
 To generate your own demos:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,7 +27,7 @@ Core pipeline with TPS and ControlNet inference, six procedure presets, clinical
 
 ---
 
-## v0.3.0 -- Data-Driven Training
+## v0.3.0: Data-Driven Training
 
 **Target:** Q3 2026
 
@@ -60,7 +60,7 @@ The focus of this release is moving from hand-tuned displacement vectors to disp
 
 ---
 
-## v0.4.0 -- 3D Face Reconstruction
+## v0.4.0: 3D Face Reconstruction
 
 **Target:** Q4 2026
 
@@ -92,7 +92,7 @@ Move from single 2D images to full 3D face reconstruction from phone video. The 
 
 ---
 
-## v0.5.0 -- Interactive 3D Surgical Preview
+## v0.5.0: Interactive 3D Surgical Preview
 
 **Target:** Q1/Q2 2027
 
@@ -115,7 +115,7 @@ End-to-end mobile workflow: the patient captures a video scan on their phone and
 
 ---
 
-## v1.0.0 -- Clinical Validation
+## v1.0.0: Clinical Validation
 
 **Target:** 2027
 
@@ -156,9 +156,9 @@ Production-ready release with clinical validation data, 3D accuracy benchmarks, 
 
 We welcome contributions at every level. See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
 
-- **New procedure presets** -- define custom displacement vectors for procedures not yet supported
-- **Clinical validation data** -- if you have access to before/after surgical datasets, we would like to hear from you
-- **Evaluation benchmarks** -- run LandmarkDiff on your own data and share results
-- **Feature requests** -- open an issue or start a [Discussion](https://github.com/dreamlessx/LandmarkDiff-public/discussions)
+- **New procedure presets**: define custom displacement vectors for procedures not yet supported
+- **Clinical validation data**: if you have access to before/after surgical datasets, we would like to hear from you
+- **Evaluation benchmarks**: run LandmarkDiff on your own data and share results
+- **Feature requests**: open an issue or start a [Discussion](https://github.com/dreamlessx/LandmarkDiff-public/discussions)
 
 Significant contributions earn co-authorship on the MICCAI 2026 paper. See the [Contributors table](../README.md#contributors) for recognition tiers.

--- a/docs/api/clinical.md
+++ b/docs/api/clinical.md
@@ -229,6 +229,6 @@ When `ehlers_danlos=True`:
 
 ## See Also
 
-- [manipulation](manipulation.md) -- `apply_procedure_preset` consumes clinical flags
-- [inference](inference.md) -- `LandmarkDiffPipeline.generate()` accepts clinical flags
-- [landmarks](landmarks.md) -- `LANDMARK_REGIONS` for valid region names
+- [manipulation](manipulation.md): `apply_procedure_preset` consumes clinical flags
+- [inference](inference.md): `LandmarkDiffPipeline.generate()` accepts clinical flags
+- [landmarks](landmarks.md): `LANDMARK_REGIONS` for valid region names

--- a/docs/api/conditioning.md
+++ b/docs/api/conditioning.md
@@ -85,9 +85,9 @@ def generate_conditioning(
 
 Generate all conditioning signals for the pipeline in one call. Produces three outputs used at different stages:
 
-1. **Landmark image** -- full 2556-edge tessellation mesh (BGR, from `render_landmark_image`). This is the primary ControlNet conditioning signal.
-2. **Canny edges** -- auto-thresholded edge map of the wireframe (grayscale). Used in compositing.
-3. **Wireframe** -- anatomical adjacency wireframe (grayscale). Used for visualization and additional conditioning.
+1. **Landmark image**: full 2556-edge tessellation mesh (BGR, from `render_landmark_image`). This is the primary ControlNet conditioning signal.
+2. **Canny edges**: auto-thresholded edge map of the wireframe (grayscale). Used in compositing.
+3. **Wireframe**: anatomical adjacency wireframe (grayscale). Used for visualization and additional conditioning.
 
 **Parameters:**
 
@@ -142,6 +142,6 @@ These are used instead of Delaunay triangulation because the topology is fixed a
 
 ## See Also
 
-- [landmarks](landmarks.md) -- `FaceLandmarks`, `render_landmark_image`
-- [manipulation](manipulation.md) -- deform landmarks before conditioning
-- [inference](inference.md) -- full pipeline that consumes conditioning images
+- [landmarks](landmarks.md): `FaceLandmarks`, `render_landmark_image`
+- [manipulation](manipulation.md): deform landmarks before conditioning
+- [inference](inference.md): full pipeline that consumes conditioning images

--- a/docs/api/evaluation.md
+++ b/docs/api/evaluation.md
@@ -295,6 +295,6 @@ print(metrics.summary())
 
 ## See Also
 
-- [inference](inference.md) -- pipeline that generates predictions to evaluate
-- [landmarks](landmarks.md) -- landmark extraction for NME computation
-- [clinical](clinical.md) -- clinical flags that affect predictions
+- [inference](inference.md): pipeline that generates predictions to evaluate
+- [landmarks](landmarks.md): landmark extraction for NME computation
+- [clinical](clinical.md): clinical flags that affect predictions

--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -213,8 +213,8 @@ Auto-detect the best available compute device. Checks MPS first (Apple Silicon),
 
 ## See Also
 
-- [landmarks](landmarks.md) -- landmark extraction and `FaceLandmarks`
-- [manipulation](manipulation.md) -- procedure preset deformations
-- [conditioning](conditioning.md) -- conditioning image generation
-- [clinical](clinical.md) -- clinical edge case flags
-- [evaluation](evaluation.md) -- metrics for evaluating predictions
+- [landmarks](landmarks.md): landmark extraction and `FaceLandmarks`
+- [manipulation](manipulation.md): procedure preset deformations
+- [conditioning](conditioning.md): conditioning image generation
+- [clinical](clinical.md): clinical edge case flags
+- [evaluation](evaluation.md): metrics for evaluating predictions

--- a/docs/api/landmarks.md
+++ b/docs/api/landmarks.md
@@ -199,6 +199,6 @@ Load an image from disk as a BGR numpy array. Raises `FileNotFoundError` if the 
 
 ## See Also
 
-- [manipulation](manipulation.md) -- apply surgical deformations to extracted landmarks
-- [conditioning](conditioning.md) -- generate ControlNet conditioning from landmarks
-- [inference](inference.md) -- full prediction pipeline
+- [manipulation](manipulation.md): apply surgical deformations to extracted landmarks
+- [conditioning](conditioning.md): generate ControlNet conditioning from landmarks
+- [inference](inference.md): full prediction pipeline

--- a/docs/api/manipulation.md
+++ b/docs/api/manipulation.md
@@ -47,12 +47,12 @@ A single deformation control point. Each handle moves its target landmark by `di
 
 | Procedure | Radius (px) | Rationale |
 |-----------|-------------|-----------|
-| `"rhinoplasty"` | 30.0 | Moderate -- smooth nasal transitions |
-| `"blepharoplasty"` | 15.0 | Tight -- avoid affecting brow |
-| `"rhytidectomy"` | 40.0 | Wide -- broad soft tissue mobilization |
-| `"orthognathic"` | 35.0 | Wide -- large jaw region |
-| `"brow_lift"` | 25.0 | Moderate -- brow and forehead |
-| `"mentoplasty"` | 25.0 | Moderate -- chin and lower contour |
+| `"rhinoplasty"` | 30.0 | Moderate: smooth nasal transitions |
+| `"blepharoplasty"` | 15.0 | Tight: avoid affecting brow |
+| `"rhytidectomy"` | 40.0 | Wide: broad soft tissue mobilization |
+| `"orthognathic"` | 35.0 | Wide: large jaw region |
+| `"brow_lift"` | 25.0 | Moderate: brow and forehead |
+| `"mentoplasty"` | 25.0 | Moderate: chin and lower contour |
 
 ---
 
@@ -153,22 +153,22 @@ deformed = apply_procedure_preset(
 
 Each procedure preset defines specific displacement vectors for different anatomical sub-regions within the targeted area. All displacements are calibrated at 512x512 resolution and scaled by `image_size / 512`.
 
-**Rhinoplasty** -- alar base narrowing (nostrils inward), tip refinement (upward rotation), dorsum narrowing (bridge squeeze).
+**Rhinoplasty**: alar base narrowing (nostrils inward), tip refinement (upward rotation), dorsum narrowing (bridge squeeze).
 
-**Blepharoplasty** -- upper lid elevation (central lid strongest), medial/lateral corner tapering (reduced displacement), subtle lower lid tightening.
+**Blepharoplasty**: upper lid elevation (central lid strongest), medial/lateral corner tapering (reduced displacement), subtle lower lid tightening.
 
-**Rhytidectomy** -- jowl lifting (upward + toward ear, strongest effect), submental tightening (upward only), temple/upper face lift (mild).
+**Rhytidectomy**: jowl lifting (upward + toward ear, strongest effect), submental tightening (upward only), temple/upper face lift (mild).
 
-**Orthognathic** -- mandible repositioning (upward), chin projection (upward), lateral jaw narrowing (bilateral symmetric inward pull).
+**Orthognathic**: mandible repositioning (upward), chin projection (upward), lateral jaw narrowing (bilateral symmetric inward pull).
 
-**Brow lift** -- brow elevation with lateral-to-medial gradient (lateral brow lifts more), forehead smoothing (subtle upward shift with wider influence radius).
+**Brow lift**: brow elevation with lateral-to-medial gradient (lateral brow lifts more), forehead smoothing (subtle upward shift with wider influence radius).
 
-**Mentoplasty** -- chin tip advancement (strongest displacement), lower contour follow-through, jaw angle transition (minimal pull for natural blending).
+**Mentoplasty**: chin tip advancement (strongest displacement), lower contour follow-through, jaw angle transition (minimal pull for natural blending).
 
 ---
 
 ## See Also
 
-- [landmarks](landmarks.md) -- `FaceLandmarks` dataclass and extraction
-- [clinical](clinical.md) -- `ClinicalFlags` for condition-specific behavior
-- [conditioning](conditioning.md) -- render deformed landmarks as ControlNet input
+- [landmarks](landmarks.md): `FaceLandmarks` dataclass and extraction
+- [clinical](clinical.md): `ClinicalFlags` for condition-specific behavior
+- [conditioning](conditioning.md): render deformed landmarks as ControlNet input

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,7 +64,7 @@ face = extract_landmarks(image)
 # Correct
 coords = face.pixel_coords     # returns (478, 2) numpy array
 
-# Wrong -- will raise TypeError
+# Wrong: will raise TypeError
 coords = face.pixel_coords()   # pixel_coords is not callable
 ```
 
@@ -170,7 +170,7 @@ The Laplacian pyramid blending should handle this, but if you see artifacts:
 
 **TPS warp looks distorted**
 
-TPS mode is purely geometric -- it pushes pixels around without any neural generation. At high intensity (>70%) the distortion becomes obvious. This is expected. Use ControlNet mode for photorealistic results.
+TPS mode is purely geometric: it pushes pixels around without any neural generation. At high intensity (>70%) the distortion becomes obvious. This is expected. Use ControlNet mode for photorealistic results.
 
 ## Training Issues
 
@@ -223,14 +223,14 @@ The Gradio demo uses `share=True` by default in Colab, which creates a public UR
 
 The project uses mypy with `--ignore-missing-imports` because several dependencies (mediapipe, insightface, lpips, etc.) do not ship type stubs. Common mypy errors and fixes:
 
-1. **`Module has no attribute`** for optional imports -- Some modules are imported conditionally with try/except. mypy cannot track these. The `pyproject.toml` already includes `[[tool.mypy.overrides]]` entries for known modules.
+1. **`Module has no attribute`** for optional imports: Some modules are imported conditionally with try/except. mypy cannot track these. The `pyproject.toml` already includes `[[tool.mypy.overrides]]` entries for known modules.
 
-2. **`Incompatible types in assignment`** with numpy -- The `pixel_coords` property returns `np.ndarray` but mypy sometimes infers a different type. Use explicit type annotations:
+2. **`Incompatible types in assignment`** with numpy: The `pixel_coords` property returns `np.ndarray` but mypy sometimes infers a different type. Use explicit type annotations:
    ```python
    coords: np.ndarray = face.pixel_coords
    ```
 
-3. **`Cannot find implementation or library stub`** -- Install type stubs:
+3. **`Cannot find implementation or library stub`**: Install type stubs:
    ```bash
    pip install types-Pillow types-PyYAML
    ```
@@ -244,21 +244,21 @@ mypy landmarkdiff/ --ignore-missing-imports
 
 The project uses pre-commit with ruff (lint + format) and mypy. Common failures:
 
-1. **ruff format** -- Code was not formatted. Fix:
+1. **ruff format**: Code was not formatted. Fix:
    ```bash
    ruff format landmarkdiff/ scripts/ tests/
    ```
 
-2. **ruff check** -- Linting errors. Fix auto-fixable ones:
+2. **ruff check**: Linting errors. Fix auto-fixable ones:
    ```bash
    ruff check --fix landmarkdiff/ scripts/ tests/
    ```
 
-3. **trailing-whitespace or end-of-file-fixer** -- These hooks auto-fix the issue. Just re-stage the files and commit again.
+3. **trailing-whitespace or end-of-file-fixer**: These hooks auto-fix the issue. Just re-stage the files and commit again.
 
-4. **check-added-large-files** -- You are trying to commit a file larger than 1MB. Use Git LFS for model checkpoints and large data files.
+4. **check-added-large-files**: You are trying to commit a file larger than 1MB. Use Git LFS for model checkpoints and large data files.
 
-5. **mypy** -- Type errors. Run `mypy landmarkdiff/ --ignore-missing-imports` to see the full report and fix errors before committing.
+5. **mypy**: Type errors. Run `mypy landmarkdiff/ --ignore-missing-imports` to see the full report and fix errors before committing.
 
 To install pre-commit hooks after cloning:
 ```bash
@@ -275,21 +275,21 @@ pre-commit run --all-files
 
 Common Docker build issues:
 
-1. **CUDA version mismatch** -- The GPU Dockerfile (`Dockerfile`) uses `nvidia/cuda:12.1.1-devel-ubuntu22.04`. If your host has a different CUDA driver version, ensure driver compatibility (CUDA 12.1 requires driver >= 530).
+1. **CUDA version mismatch**: The GPU Dockerfile (`Dockerfile`) uses `nvidia/cuda:12.1.1-devel-ubuntu22.04`. If your host has a different CUDA driver version, ensure driver compatibility (CUDA 12.1 requires driver >= 530).
 
-2. **Out of disk space** -- The GPU image is large (~10 GB). Clean old images:
+2. **Out of disk space**: The GPU image is large (~10 GB). Clean old images:
    ```bash
    docker system prune -a
    ```
 
-3. **pip install fails inside container** -- Network issues or missing system packages. The Dockerfiles install the required system libraries (`libgl1-mesa-glx`, `libglib2.0-0`, etc.). If you modified the Dockerfile and see `ImportError: libGL.so.1`, add:
+3. **pip install fails inside container**: Network issues or missing system packages. The Dockerfiles install the required system libraries (`libgl1-mesa-glx`, `libglib2.0-0`, etc.). If you modified the Dockerfile and see `ImportError: libGL.so.1`, add:
    ```dockerfile
    RUN apt-get update && apt-get install -y libgl1-mesa-glx
    ```
 
 4. **CPU Dockerfile (`Dockerfile.cpu`)** installs CPU-only PyTorch from `https://download.pytorch.org/whl/cpu`. If you need GPU support, use the main `Dockerfile` instead.
 
-5. **Permission errors with mounted volumes** -- The container runs as root by default. If you mount host directories, ensure the directories exist and are writable:
+5. **Permission errors with mounted volumes**: The container runs as root by default. If you mount host directories, ensure the directories exist and are writable:
    ```bash
    mkdir -p data checkpoints
    docker compose up app
@@ -297,18 +297,18 @@ Common Docker build issues:
 
 **Sphinx documentation build fails**
 
-1. **Missing dependencies** -- Install the docs requirements:
+1. **Missing dependencies**: Install the docs requirements:
    ```bash
    pip install -r docs/requirements.txt
    ```
    Required packages: `sphinx>=7.0`, `furo`, `myst-parser`, `sphinx-autodoc-typehints`, `sphinx-copybutton`.
 
-2. **MyST markdown parse errors** -- The docs use MyST-flavored markdown. Common issues:
+2. **MyST markdown parse errors**: The docs use MyST-flavored markdown. Common issues:
    - Directive syntax uses `{toctree}` not `:toctree:` in code fences.
    - Heading levels must not skip (e.g., going from `#` to `###` without `##` in between).
    - Indentation inside directives must be consistent.
 
-3. **autodoc import errors** -- Sphinx tries to import `landmarkdiff` to generate API docs. Install the package first:
+3. **autodoc import errors**: Sphinx tries to import `landmarkdiff` to generate API docs. Install the package first:
    ```bash
    pip install -e .
    sphinx-build -b html docs/ docs/_build/html

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,10 +19,10 @@ It works by extracting MediaPipe's 478-point face mesh from the input photo, app
 
 ## Quick Links
 
-- [Quickstart notebook](../examples/quickstart.ipynb) -- load the pipeline, run predictions, compare procedures
-- [CHANGELOG](../CHANGELOG.md) -- what changed between releases
-- [Discussions](https://github.com/dreamlessx/LandmarkDiff-public/discussions) -- questions, ideas, and community discussion
-- [API reference](api/) -- per-module documentation
+- [Quickstart notebook](../examples/quickstart.ipynb): load the pipeline, run predictions, compare procedures
+- [CHANGELOG](../CHANGELOG.md): what changed between releases
+- [Discussions](https://github.com/dreamlessx/LandmarkDiff-public/discussions): questions, ideas, and community discussion
+- [API reference](api/): per-module documentation
 
 ---
 
@@ -829,7 +829,7 @@ make clean           # remove build artifacts
   title={LandmarkDiff: Anatomically-Conditioned Latent Diffusion for
          Photorealistic Facial Surgery Outcome Prediction},
   booktitle={Medical Image Computing and Computer Assisted Intervention
-             -- MICCAI},
+            : MICCAI},
   year={2026},
   publisher={Springer}
 }

--- a/docs/paper/figures_readme.md
+++ b/docs/paper/figures_readme.md
@@ -99,15 +99,15 @@ paper/figures/
 
 ### General
 
-- `scripts/generate_figures.py` -- general-purpose figure generation
-- `scripts/generate_qualitative_figure.py` -- qualitative comparison grids
-- `scripts/generate_paper_tables.py` -- LaTeX tables for the results section
-- `scripts/populate_paper_tables.py` -- fills table placeholders with computed metrics
-- `scripts/json_to_latex.py` -- converts JSON evaluation results to LaTeX tables
+- `scripts/generate_figures.py`: general-purpose figure generation
+- `scripts/generate_qualitative_figure.py`: qualitative comparison grids
+- `scripts/generate_paper_tables.py`: LaTeX tables for the results section
+- `scripts/populate_paper_tables.py`: fills table placeholders with computed metrics
+- `scripts/json_to_latex.py`: converts JSON evaluation results to LaTeX tables
 
 ### New in v0.2.2
 
-- `scripts/build_qualitative_grid.py` -- multi-procedure qualitative comparison grid suitable for the main paper figure. Accepts a directory of input faces and produces a single composited PNG with one row per face and one column per procedure.
+- `scripts/build_qualitative_grid.py`: multi-procedure qualitative comparison grid suitable for the main paper figure. Accepts a directory of input faces and produces a single composited PNG with one row per face and one column per procedure.
 
   ```bash
   python scripts/build_qualitative_grid.py \
@@ -117,7 +117,7 @@ paper/figures/
       --intensity 65
   ```
 
-- `scripts/generate_comparison_figure.py` -- side-by-side comparison of LandmarkDiff against baseline methods (TPS-only, SD img2img). Used for Table 1 row visualization.
+- `scripts/generate_comparison_figure.py`: side-by-side comparison of LandmarkDiff against baseline methods (TPS-only, SD img2img). Used for Table 1 row visualization.
 
   ```bash
   python scripts/generate_comparison_figure.py \
@@ -126,7 +126,7 @@ paper/figures/
       --procedure rhinoplasty
   ```
 
-- `scripts/landmark_accuracy_heatmap.py` -- generates a 478-point landmark error heatmap overlaid on the canonical face mesh. Color-codes per-landmark NME from a saved evaluation JSON.
+- `scripts/landmark_accuracy_heatmap.py`: generates a 478-point landmark error heatmap overlaid on the canonical face mesh. Color-codes per-landmark NME from a saved evaluation JSON.
 
   ```bash
   python scripts/landmark_accuracy_heatmap.py \
@@ -135,7 +135,7 @@ paper/figures/
       --procedure rhinoplasty
   ```
 
-- `scripts/visualize_attention.py` -- extracts and visualizes ControlNet cross-attention maps at each denoising step. Produces per-step attention overlays and a summary strip.
+- `scripts/visualize_attention.py`: extracts and visualizes ControlNet cross-attention maps at each denoising step. Produces per-step attention overlays and a summary strip.
 
   ```bash
   python scripts/visualize_attention.py \
@@ -146,7 +146,7 @@ paper/figures/
       --steps 30
   ```
 
-- `scripts/visualize_latent_space.py` -- projects latent codes from a set of generated images into 2D via UMAP or PCA. Points are colored by procedure, producing a scatter plot that shows procedure-level clustering.
+- `scripts/visualize_latent_space.py`: projects latent codes from a set of generated images into 2D via UMAP or PCA. Points are colored by procedure, producing a scatter plot that shows procedure-level clustering.
 
   ```bash
   python scripts/visualize_latent_space.py \
@@ -156,7 +156,7 @@ paper/figures/
       --projection umap
   ```
 
-- `scripts/progressive_denoising.py` -- renders a horizontal strip showing the diffusion output at selected denoising steps (e.g., t=1000, 800, 600, 400, 200, 0). Useful for the supplementary denoising trajectory figure.
+- `scripts/progressive_denoising.py`: renders a horizontal strip showing the diffusion output at selected denoising steps (e.g., t=1000, 800, 600, 400, 200, 0). Useful for the supplementary denoising trajectory figure.
 
   ```bash
   python scripts/progressive_denoising.py \
@@ -167,7 +167,7 @@ paper/figures/
       --steps 30
   ```
 
-- `scripts/intensity_sweep.py` -- generates a horizontal strip of outputs at 0%, 20%, 40%, 60%, 80%, 100% intensity for a single face and procedure. Used in the supplementary S1 tables and figures.
+- `scripts/intensity_sweep.py`: generates a horizontal strip of outputs at 0%, 20%, 40%, 60%, 80%, 100% intensity for a single face and procedure. Used in the supplementary S1 tables and figures.
 
   ```bash
   python scripts/intensity_sweep.py \

--- a/docs/paper/supplementary.md
+++ b/docs/paper/supplementary.md
@@ -21,7 +21,7 @@ All tables and figures in this document can be reproduced using the scripts list
 | Denoising trajectory | `scripts/progressive_denoising.py` | Denoising strip for any procedure |
 | Landmark heatmap | `scripts/landmark_accuracy_heatmap.py` | Per-landmark NME heatmap |
 
-Quick example -- reproduce S1 for rhinoplasty at all intensities:
+Quick example: reproduce S1 for rhinoplasty at all intensities:
 
 ```bash
 python scripts/intensity_sweep.py \

--- a/docs/social_media_drafts.md
+++ b/docs/social_media_drafts.md
@@ -1,4 +1,4 @@
-# Social Media Drafts -- LandmarkDiff
+# Social Media Drafts: LandmarkDiff
 
 All drafts are written from the perspective of `dreamlessx`.
 Links:
@@ -10,7 +10,7 @@ Links:
 
 ---
 
-## 1. r/MachineLearning -- [Project] Post
+## 1. r/MachineLearning: [Project] Post
 
 **Flair**: [Project]
 
@@ -37,14 +37,14 @@ and mentoplasty (chin).
 
 The pipeline has three stages:
 
-1. **Landmark extraction** -- MediaPipe FaceMesh extracts 478 3D facial landmarks. These define
+1. **Landmark extraction**: MediaPipe FaceMesh extracts 478 3D facial landmarks. These define
    anatomically meaningful control points across the face.
 
-2. **Procedure-specific deformation** -- Gaussian RBF (radial basis function) interpolation drives
+2. **Procedure-specific deformation**: Gaussian RBF (radial basis function) interpolation drives
    landmark displacements that correspond to each procedure's anatomical effect. There is also a
    data-driven displacement mode that fits displacement fields from real before/after surgery pairs.
 
-3. **Conditioned synthesis** -- Deformed landmark positions are rendered as a wireframe and fed
+3. **Conditioned synthesis**: Deformed landmark positions are rendered as a wireframe and fed
    as a conditioning input to a ControlNet-conditioned Stable Diffusion 1.5 pipeline (built on
    CrucibleAI's ControlNet). The wireframe spatially grounds the diffusion process to the predicted
    anatomy rather than letting the model hallucinate structure.
@@ -92,7 +92,7 @@ The core vision pipeline:
 - Extract 478 anatomical control points with MediaPipe FaceMesh
 - Apply procedure-specific Gaussian RBF displacements (rhinoplasty, brow lift, facelift, etc.)
 - Fit thin-plate spline (TPS) warp from original to displaced control points
-- Apply warp to the full image -- fast, smooth, and anatomically consistent
+- Apply warp to the full image: fast, smooth, and anatomically consistent
 - Optionally pass the warped result through ControlNet + SD1.5 for texture synthesis
 
 The TPS CPU demo runs in-browser on HF Spaces, no GPU needed. The ControlNet GPU pipeline
@@ -110,7 +110,7 @@ Disclaimer: research tool, not medical advice.
 
 **Title**:
 ```
-Using facial mesh wireframes as ControlNet conditioning inputs for surgery outcome prediction -- LandmarkDiff
+Using facial mesh wireframes as ControlNet conditioning inputs for surgery outcome prediction: LandmarkDiff
 ```
 
 **Body**:
@@ -122,7 +122,7 @@ spatial prior for surgical outcome synthesis.
 
 Standard ControlNet-based generation takes a conditioning image (edges, pose, depth, etc.) and
 guides the diffusion process spatially. In LandmarkDiff, the conditioning input is a rendered
-wireframe of *deformed* facial landmarks -- the face mesh after procedure-specific landmark
+wireframe of *deformed* facial landmarks: the face mesh after procedure-specific landmark
 displacements are applied.
 
 The deformation is driven by Gaussian RBF interpolation on MediaPipe's 478-point 3D face mesh.
@@ -144,7 +144,7 @@ anatomy rather than being free to move facial features arbitrarily. This is impo
 surgical visualization, where geometric plausibility is as important as texture quality.
 
 There is also a lightweight CPU mode (`tps`) that skips diffusion entirely and produces a pure
-TPS warp -- useful for fast preview without GPU.
+TPS warp: useful for fast preview without GPU.
 
 Code (MIT): https://github.com/dreamlessx/LandmarkDiff-public
 Demo (CPU TPS + GPU ControlNet): https://huggingface.co/spaces/dreamlessx/LandmarkDiff
@@ -158,7 +158,7 @@ Disclaimer: research tool, not medical advice.
 
 **Title**:
 ```
-Open-source research tool for visualizing facial surgery outcomes from a single photo -- LandmarkDiff
+Open-source research tool for visualizing facial surgery outcomes from a single photo: LandmarkDiff
 ```
 
 **Body**:
@@ -226,7 +226,7 @@ Thread below.
 
 **Tweet 2 (the face mesh)**:
 ```
-2/ The geometric backbone is MediaPipe FaceMesh -- 478 3D landmarks per frame.
+2/ The geometric backbone is MediaPipe FaceMesh: 478 3D landmarks per frame.
 
 These aren't just face keypoints. They cover the full facial surface: orbit, nasal cartilage,
 lip, chin, forehead, zygomatic arch.
@@ -298,7 +298,7 @@ Feedback, contributions, and forks welcome.
 
 **Title**:
 ```
-Show HN: LandmarkDiff -- facial surgery outcome prediction with MediaPipe mesh + ControlNet SD1.5
+Show HN: LandmarkDiff: facial surgery outcome prediction with MediaPipe mesh + ControlNet SD1.5
 ```
 
 **Description**:
@@ -314,7 +314,7 @@ orthognathic surgery, brow lift, and mentoplasty.
 
 The pipeline has four inference modes:
 
-- tps: thin-plate spline warp, CPU only, no diffusion -- fast and useful as a geometric baseline
+- tps: thin-plate spline warp, CPU only, no diffusion: fast and useful as a geometric baseline
 - img2img: standard SD1.5 img2img conditioned on the warped image
 - controlnet: ControlNet conditioning on the deformed wireframe for spatially grounded synthesis
 - controlnet_ip: adds IP-Adapter for stronger patient identity preservation

--- a/docs/tutorials/custom_procedures.md
+++ b/docs/tutorials/custom_procedures.md
@@ -10,7 +10,7 @@ Both PRs are good references for the scope of changes needed.
 
 ## How It Works
 
-LandmarkDiff uses **Gaussian RBF (Radial Basis Function) deformation** to move facial landmarks. Each procedure is defined by a list of **deformation handles** -- anchor points on the face that get displaced in a specific direction, with influence that falls off smoothly to neighboring landmarks.
+LandmarkDiff uses **Gaussian RBF (Radial Basis Function) deformation** to move facial landmarks. Each procedure is defined by a list of **deformation handles**: anchor points on the face that get displaced in a specific direction, with influence that falls off smoothly to neighboring landmarks.
 
 A deformation handle has three components:
 - **`landmark_index`**: which MediaPipe landmark to move (0-477)

--- a/docs/tutorials/deployment.md
+++ b/docs/tutorials/deployment.md
@@ -87,9 +87,9 @@ docker compose --profile training run train
 
 All services mount these volumes:
 
-- `./data:/app/data` -- training data, test pairs
-- `./checkpoints:/app/checkpoints` -- model checkpoints
-- `model-cache:/root/.cache` -- shared HuggingFace model cache
+- `./data:/app/data`: training data, test pairs
+- `./checkpoints:/app/checkpoints`: model checkpoints
+- `model-cache:/root/.cache`: shared HuggingFace model cache
 
 Create the host directories before running:
 
@@ -118,9 +118,9 @@ RUN python -c "from diffusers import ControlNetModel; ControlNetModel.from_pretr
 1. Create a new Space at [huggingface.co/new-space](https://huggingface.co/new-space).
 2. Select **Gradio** as the SDK.
 3. Choose hardware:
-   - **CPU Basic** (free) -- works for TPS mode only
-   - **T4 Small** -- minimum for ControlNet inference
-   - **A10G Small** -- recommended for faster inference
+   - **CPU Basic** (free): works for TPS mode only
+   - **T4 Small**: minimum for ControlNet inference
+   - **A10G Small**: recommended for faster inference
 4. Push the repository contents to the Space.
 
 The `scripts/app.py` Gradio demo is compatible with HuggingFace Spaces out of the box. It auto-detects the environment and sets `share=False` (Spaces already provides a public URL).
@@ -146,8 +146,8 @@ pinned: false
 
 Set secrets in the Space settings (Settings > Repository Secrets):
 
-- `HF_TOKEN` -- if using gated models
-- `LANDMARKDIFF_MODE` -- set to `tps` for CPU Spaces
+- `HF_TOKEN`: if using gated models
+- `LANDMARKDIFF_MODE`: set to `tps` for CPU Spaces
 
 ### Persistence
 
@@ -180,7 +180,7 @@ from landmarkdiff.inference import LandmarkDiffPipeline
 
 logger = logging.getLogger(__name__)
 
-# Pipeline singleton -- loaded once at startup
+# Pipeline singleton: loaded once at startup
 _pipeline = None
 
 
@@ -498,6 +498,6 @@ async def predict(...):
 
 ## Next Steps
 
-- [Evaluation Guide](evaluation.md) -- Measure model quality
-- [Training Guide](training.md) -- Train your own checkpoint
-- [FAQ](../faq.md) -- Common questions and troubleshooting
+- [Evaluation Guide](evaluation.md): Measure model quality
+- [Training Guide](training.md): Train your own checkpoint
+- [FAQ](../faq.md): Common questions and troubleshooting

--- a/docs/tutorials/evaluation.md
+++ b/docs/tutorials/evaluation.md
@@ -16,7 +16,7 @@ This pulls in `lpips`, `torch-fidelity`, `scikit-image`, and `insightface` (for 
 
 LandmarkDiff ships four evaluation scripts, each suited to a different workflow.
 
-### scripts/evaluate.py -- Full pipeline evaluation
+### scripts/evaluate.py: Full pipeline evaluation
 
 Runs inference on test pairs and computes all metrics end-to-end. Use this when you want to evaluate a checkpoint against paired before/after images.
 
@@ -75,7 +75,7 @@ If a `metadata.json` file exists, it should map pair IDs to procedure and intens
 }
 ```
 
-### scripts/evaluate_quality.py -- Metric-only evaluation
+### scripts/evaluate_quality.py: Metric-only evaluation
 
 Computes metrics on existing predictions without running inference. Useful when you already have generated images and just need the numbers.
 
@@ -96,11 +96,11 @@ python scripts/evaluate_quality.py \
 ```
 
 This produces three output files:
-- `quality_results.json` -- aggregate and stratified metrics
-- `quality_per_sample.json` -- per-image breakdown
-- `quality_results.md` -- markdown table for papers or PRs
+- `quality_results.json`: aggregate and stratified metrics
+- `quality_per_sample.json`: per-image breakdown
+- `quality_results.md`: markdown table for papers or PRs
 
-### scripts/evaluate_checkpoint.py -- Checkpoint evaluation
+### scripts/evaluate_checkpoint.py: Checkpoint evaluation
 
 Evaluates a trained ControlNet checkpoint directly by loading the model, running generation from conditioning images, and computing all metrics. This bypasses the full LandmarkDiffPipeline and tests the ControlNet in isolation.
 
@@ -116,7 +116,7 @@ python scripts/evaluate_checkpoint.py \
 
 When `--save_images` is set, it saves side-by-side comparison images (conditioning | generated | target) for visual inspection.
 
-### scripts/evaluate_on_hda.py -- Clinical ground truth evaluation
+### scripts/evaluate_on_hda.py: Clinical ground truth evaluation
 
 Evaluates against real surgery before/after pairs from the HDA dataset. This is the clinical validation script.
 
@@ -182,7 +182,7 @@ python scripts/evaluate_on_hda.py \
 
 **Target:** < 50.
 
-**Interpretation:** FID below 30 indicates high-quality generation. Between 30 and 50 is acceptable. Above 100 suggests the model is producing unrealistic images. FID is sensitive to dataset size -- with fewer than 50 images, the estimate is unstable.
+**Interpretation:** FID below 30 indicates high-quality generation. Between 30 and 50 is acceptable. Above 100 suggests the model is producing unrealistic images. FID is sensitive to dataset size: with fewer than 50 images, the estimate is unstable.
 
 **Requirements:** The `torch-fidelity` package. Runs on GPU if available, CPU otherwise (much slower).
 
@@ -194,7 +194,7 @@ python scripts/evaluate_on_hda.py \
 
 **Target:** > 0.85.
 
-**Interpretation:** Above 0.90 is strong identity preservation. Between 0.80 and 0.90 is acceptable. Below 0.60 triggers the pipeline's identity drift warning. Orthognathic surgery typically has lower identity similarity because jaw repositioning changes facial proportions substantially -- this is expected and the pipeline disables identity loss for orthognathic predictions during training.
+**Interpretation:** Above 0.90 is strong identity preservation. Between 0.80 and 0.90 is acceptable. Below 0.60 triggers the pipeline's identity drift warning. Orthognathic surgery typically has lower identity similarity because jaw repositioning changes facial proportions substantially: this is expected and the pipeline disables identity loss for orthognathic predictions during training.
 
 **Fallback:** If InsightFace is not installed, falls back to SSIM as a rough proxy for identity similarity.
 
@@ -414,6 +414,6 @@ results_dict = metrics.to_dict()
 
 ## Next Steps
 
-- [Training Guide](training.md) -- Train your own ControlNet checkpoint
-- [Deployment Guide](deployment.md) -- Deploy models for production inference
-- [GPU Training Guide](../GPU_TRAINING_GUIDE.md) -- HPC setup and multi-GPU training
+- [Training Guide](training.md): Train your own ControlNet checkpoint
+- [Deployment Guide](deployment.md): Deploy models for production inference
+- [GPU Training Guide](../GPU_TRAINING_GUIDE.md): HPC setup and multi-GPU training

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -65,10 +65,10 @@ result = pipeline.generate("photo.jpg", procedure="rhinoplasty", intensity=60)
 ```
 
 The `result` dictionary contains:
-- `result["output"]` -- the final composited image
-- `result["input"]` -- the original 512x512 input
-- `result["conditioning"]` -- the deformed wireframe mesh overlay
-- `result["mask"]` -- the surgical region mask
+- `result["output"]`: the final composited image
+- `result["input"]`: the original 512x512 input
+- `result["conditioning"]`: the deformed wireframe mesh overlay
+- `result["mask"]`: the surgical region mask
 
 ## 4. GPU Mode (Photorealistic Results)
 
@@ -178,10 +178,10 @@ step2 = apply_procedure_preset(step1, "mentoplasty", intensity=40)
 
 ## Next Steps
 
-- [Custom Procedures](custom_procedures.md) -- define your own surgical procedure preset
-- [Training](training.md) -- train on your own data
-- [Evaluation](evaluation.md) -- evaluate prediction quality with metrics
-- [Deployment](deployment.md) -- deploy as an API or Docker service
-- [API Reference](../api/landmarks.md) -- full module documentation
-- [Procedure Docs](../procedures/rhinoplasty.md) -- detailed anatomy and displacement info for each procedure
-- [Interactive Notebook](https://github.com/dreamlessx/LandmarkDiff-public/blob/main/notebooks/quickstart.ipynb) -- step-by-step Jupyter notebook with visualizations
+- [Custom Procedures](custom_procedures.md): define your own surgical procedure preset
+- [Training](training.md): train on your own data
+- [Evaluation](evaluation.md): evaluate prediction quality with metrics
+- [Deployment](deployment.md): deploy as an API or Docker service
+- [API Reference](../api/landmarks.md): full module documentation
+- [Procedure Docs](../procedures/rhinoplasty.md): detailed anatomy and displacement info for each procedure
+- [Interactive Notebook](https://github.com/dreamlessx/LandmarkDiff-public/blob/main/notebooks/quickstart.ipynb): step-by-step Jupyter notebook with visualizations

--- a/docs/tutorials/training.md
+++ b/docs/tutorials/training.md
@@ -6,8 +6,8 @@ Train LandmarkDiff from scratch on your own data. This guide covers every step: 
 
 Training has two phases:
 
-1. **Phase A** (synthetic data, diffusion loss only) -- teaches the model to generate faces conditioned on deformed landmark meshes
-2. **Phase B** (clinical data, full loss) -- fine-tunes on real surgical before/after pairs with identity and perceptual losses
+1. **Phase A** (synthetic data, diffusion loss only): teaches the model to generate faces conditioned on deformed landmark meshes
+2. **Phase B** (clinical data, full loss): fine-tunes on real surgical before/after pairs with identity and perceptual losses
 
 The multi-term loss for Phase B:
 
@@ -592,7 +592,7 @@ These settings are non-negotiable. Training will produce garbage without them:
 
 ## Next Steps
 
-- [Evaluation](evaluation.md) -- evaluate your trained checkpoints
-- [Custom Procedures](custom_procedures.md) -- add new surgical procedures
-- [GPU Training Guide](../GPU_TRAINING_GUIDE.md) -- HPC-specific setup details
-- [Deployment](deployment.md) -- deploy your trained model
+- [Evaluation](evaluation.md): evaluate your trained checkpoints
+- [Custom Procedures](custom_procedures.md): add new surgical procedures
+- [GPU Training Guide](../GPU_TRAINING_GUIDE.md): HPC-specific setup details
+- [Deployment](deployment.md): deploy your trained model

--- a/docs/wiki/API-Reference.md
+++ b/docs/wiki/API-Reference.md
@@ -249,10 +249,10 @@ field = model.get_displacement_field(
 ```
 
 **Properties:**
-- `procedures` -- list of procedure names the model was fitted on
-- `fitted` -- whether the model has been fitted
-- `stats` -- nested dict of per-procedure statistics
-- `n_samples` -- dict of sample counts per procedure
+- `procedures`: list of procedure names the model was fitted on
+- `fitted`: whether the model has been fitted
+- `stats`: nested dict of per-procedure statistics
+- `n_samples`: dict of sample counts per procedure
 
 ### `extract_displacements(before_img, after_img) -> dict | None`
 

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -80,13 +80,13 @@ When a `DisplacementModel` (fitted from real before/after surgery pairs) is avai
 ## Stage 3: Generation
 
 ### TPS Mode (CPU)
-Pure geometric thin-plate spline warp. Maps original landmark positions to deformed positions and interpolates the full image. No diffusion model needed -- results are instant but lack the photorealistic texture synthesis of diffusion modes.
+Pure geometric thin-plate spline warp. Maps original landmark positions to deformed positions and interpolates the full image. No diffusion model needed: results are instant but lack the photorealistic texture synthesis of diffusion modes.
 
 ### img2img Mode
 Feeds the TPS-warped image into SD1.5 img2img pipeline with a procedure-specific prompt. A surgical mask (convex hull of procedure landmarks, dilated + feathered) controls the compositing region.
 
 ### ControlNet Mode
-Renders the deformed face mesh as a wireframe (2556-edge tessellation matching what CrucibleAI's ControlNet was trained on) and uses it as conditioning. The full MediaPipe tessellation and contour edges are drawn -- thin gray lines for tessellation, brighter white for contours. Uses DPM++ 2M Karras scheduler for photorealistic output.
+Renders the deformed face mesh as a wireframe (2556-edge tessellation matching what CrucibleAI's ControlNet was trained on) and uses it as conditioning. The full MediaPipe tessellation and contour edges are drawn: thin gray lines for tessellation, brighter white for contours. Uses DPM++ 2M Karras scheduler for photorealistic output.
 
 ### ControlNet + IP-Adapter Mode
 Extends ControlNet mode with h94/IP-Adapter-FaceID to condition generation on the input face embedding. This provides stronger identity preservation. The IP-Adapter scale defaults to 0.6.
@@ -95,17 +95,17 @@ Extends ControlNet mode with h94/IP-Adapter-FaceID to condition generation on th
 
 The post-processing pipeline applies six steps:
 
-1. **CodeFormer** -- Transformer-based face restoration using codebook lookup. Fidelity parameter (default 0.7) balances quality vs. identity preservation. Falls back to GFPGAN if unavailable.
+1. **CodeFormer**: Transformer-based face restoration using codebook lookup. Fidelity parameter (default 0.7) balances quality vs. identity preservation. Falls back to GFPGAN if unavailable.
 
-2. **Real-ESRGAN** -- Neural 4x upscaler applied only to background (non-face) regions, then downsampled back. Improves overall sharpness without interfering with the face restoration.
+2. **Real-ESRGAN**: Neural 4x upscaler applied only to background (non-face) regions, then downsampled back. Improves overall sharpness without interfering with the face restoration.
 
-3. **Histogram matching** -- CDF-based color matching in LAB space within the mask region. Ensures the generated face matches the original skin tone distribution, not just mean/std.
+3. **Histogram matching**: CDF-based color matching in LAB space within the mask region. Ensures the generated face matches the original skin tone distribution, not just mean/std.
 
-4. **Frequency-aware sharpening** -- Unsharp mask in LAB luminance channel only. Recovers fine skin texture (pores, fine lines) that diffusion tends to smooth out. Avoids color fringing by working in luminance only.
+4. **Frequency-aware sharpening**: Unsharp mask in LAB luminance channel only. Recovers fine skin texture (pores, fine lines) that diffusion tends to smooth out. Avoids color fringing by working in luminance only.
 
-5. **Laplacian pyramid blending** -- Multi-band blending at 6 pyramid levels. Low frequencies blend smoothly (no color seams), high frequencies transition sharply (preserving hair/texture boundaries). Replaces the visible halos from simple alpha blending.
+5. **Laplacian pyramid blending**: Multi-band blending at 6 pyramid levels. Low frequencies blend smoothly (no color seams), high frequencies transition sharply (preserving hair/texture boundaries). Replaces the visible halos from simple alpha blending.
 
-6. **ArcFace identity verification** -- Computes cosine similarity between ArcFace embeddings of the original and output. Flags identity drift if similarity drops below 0.6 (configurable threshold).
+6. **ArcFace identity verification**: Computes cosine similarity between ArcFace embeddings of the original and output. Flags identity drift if similarity drops below 0.6 (configurable threshold).
 
 ## Mask Generation
 

--- a/docs/wiki/Clinical-Flags.md
+++ b/docs/wiki/Clinical-Flags.md
@@ -57,7 +57,7 @@ result = pipe.generate(image, clinical_flags=flags)
 2. During `apply_procedure_preset()`, deformation handles whose `landmark_index` falls on the affected side are removed from the handle list. Only the healthy side receives deformation.
 
 **Parameters:**
-- `bells_palsy_side`: Which side is affected -- `"left"` or `"right"`
+- `bells_palsy_side`: Which side is affected: `"left"` or `"right"`
 
 **Affected landmark groups (left side example):**
 - Eye: 33, 7, 163, 144, 145, 153, 154, 155, 133, 173, 157, 158, 159, 160, 161, 246
@@ -92,7 +92,7 @@ result = pipe.generate(image, clinical_flags=flags)
 
 In `apply_procedure_preset()`, when `clinical_flags.ehlers_danlos` is True, the procedure's influence radius is multiplied by 1.5 before building deformation handles. For example, rhinoplasty's radius goes from 30.0 to 45.0, and rhytidectomy's from 40.0 to 60.0.
 
-This single change affects all downstream deformations -- each handle's Gaussian RBF falloff covers a wider area, creating broader, more distributed tissue displacement.
+This single change affects all downstream deformations: each handle's Gaussian RBF falloff covers a wider area, creating broader, more distributed tissue displacement.
 
 ## Combining Flags
 

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -22,14 +22,14 @@ Thanks for your interest in contributing to LandmarkDiff. This project is active
 ## What We Need Help With
 
 ### High Priority
-- **New procedure presets** -- define displacement vectors for additional surgical procedures (e.g., otoplasty, lip augmentation)
-- **Clinical validation** -- if you have access to pre/post-operative photo datasets, we would love to collaborate
-- **Multi-view consistency** -- improving prediction quality across different face angles
+- **New procedure presets**: define displacement vectors for additional surgical procedures (e.g., otoplasty, lip augmentation)
+- **Clinical validation**: if you have access to pre/post-operative photo datasets, we would love to collaborate
+- **Multi-view consistency**: improving prediction quality across different face angles
 
 ### Medium Priority
-- **Evaluation metrics** -- domain-specific metrics for surgical outcome quality
-- **Data augmentation** -- new clinical photography degradation types
-- **Performance** -- faster inference, reduced memory usage, batched processing
+- **Evaluation metrics**: domain-specific metrics for surgical outcome quality
+- **Data augmentation**: new clinical photography degradation types
+- **Performance**: faster inference, reduced memory usage, batched processing
 
 ### Always Welcome
 - Bug fixes

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -28,7 +28,7 @@ See the detailed guide on the [Contributing](Contributing) page. In summary:
 
 **TPS (Thin Plate Spline):**
 - CPU-only, instant results (~50ms)
-- Pure geometric warp -- moves pixels, no texture synthesis
+- Pure geometric warp: moves pixels, no texture synthesis
 - Good for quick previews and interactive demos
 - No model download needed
 
@@ -72,7 +72,7 @@ Three mechanisms protect identity:
 
 2. **IP-Adapter (controlnet_ip mode):** Feeds an ArcFace embedding of the input face into the generation process, biasing SD1.5 toward preserving the person's identity.
 
-3. **ArcFace verification (post-processing):** After generation, cosine similarity between ArcFace embeddings of input and output is computed. If it drops below 0.6, the output is flagged with an identity drift warning. This is a quality gate, not a rejection -- the output is still returned.
+3. **ArcFace verification (post-processing):** After generation, cosine similarity between ArcFace embeddings of input and output is computed. If it drops below 0.6, the output is flagged with an identity drift warning. This is a quality gate, not a rejection: the output is still returned.
 
 ## What face poses are supported?
 
@@ -97,7 +97,7 @@ pipe = LandmarkDiffPipeline(
 )
 ```
 
-Any SD1.5-compatible checkpoint should work. SD2.x and SDXL checkpoints are not supported -- the ControlNet is trained specifically for SD1.5's architecture.
+Any SD1.5-compatible checkpoint should work. SD2.x and SDXL checkpoints are not supported: the ControlNet is trained specifically for SD1.5's architecture.
 
 ## What image formats are supported?
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -23,7 +23,7 @@ LandmarkDiff predicts post-surgical facial appearance by combining MediaPipe 478
 
 | Page | Description |
 |------|-------------|
-| [Architecture](Architecture) | Full pipeline diagram -- from face mesh extraction to post-processing |
+| [Architecture](Architecture) | Full pipeline diagram, from face mesh extraction to post-processing |
 | [Procedures](Procedures) | All 6 supported surgical procedures with landmark indices and displacement patterns |
 | [API Reference](API-Reference) | Key classes: `LandmarkDiffPipeline`, `FaceLandmarks`, `DeformationHandle`, etc. |
 | [Configuration](Configuration) | YAML experiment config schema, CLI flags, environment variables |

--- a/docs/wiki/Procedures.md
+++ b/docs/wiki/Procedures.md
@@ -31,7 +31,7 @@ Bilateral squeeze of the nasal bridge. Left dorsum (195, 197, 236) moves right, 
 Targets the periorbital region with three effects:
 
 ### Upper Lid Elevation (Primary)
-Central upper lid landmarks move upward. Left: 159, 160, 161. Right: 386, 385, 384. Displacement: (0, -2.0 * scale). This is the primary surgical effect -- removing excess skin/fat from the upper eyelid.
+Central upper lid landmarks move upward. Left: 159, 160, 161. Right: 386, 385, 384. Displacement: (0, -2.0 * scale). This is the primary surgical effect: removing excess skin/fat from the upper eyelid.
 
 ### Corner Tapering
 Medial and lateral lid corners receive reduced displacement for a natural tapered effect. Left: 158, 157, 133, 33. Right: 387, 388, 362, 263. Displacement: (0, -0.8 * scale) at 0.7x influence radius.
@@ -42,7 +42,7 @@ Subtle upward pull on lower lid landmarks. Left: 145, 153, 154. Right: 374, 380,
 **Full landmark set (28 indices):**
 `33, 7, 163, 144, 145, 153, 154, 155, 157, 158, 159, 160, 161, 246, 362, 382, 381, 380, 374, 373, 390, 249, 263, 466, 388, 387, 386, 385, 384, 398`
 
-**Clinical note:** The tight influence radius (15px) is important here -- the periorbital region is small and spreading deformation too far creates unnatural cheek distortion.
+**Clinical note:** The tight influence radius (15px) is important here: the periorbital region is small and spreading deformation too far creates unnatural cheek distortion.
 
 ---
 
@@ -56,7 +56,7 @@ The most complex procedure, targeting three facial zones with different displace
 Bilateral lift toward the ears. Left jowl (132, 136, 172, 58, 150, 176): displacement (-2.5 * scale, -3.0 * scale). Right jowl (361, 365, 397, 288, 379, 400): displacement (+2.5 * scale, -3.0 * scale). Full influence radius. The lateral+vertical pull simulates the SMAS plication direction.
 
 ### Submental / Chin
-Upward-only displacement on chin landmarks (152, 148, 377, 378). Displacement: (0, -2.0 * scale) at 0.8x radius. No lateral movement -- this region doesn't benefit from lateral tension.
+Upward-only displacement on chin landmarks (152, 148, 377, 378). Displacement: (0, -2.0 * scale) at 0.8x radius. No lateral movement: this region doesn't benefit from lateral tension.
 
 ### Temple / Upper Face
 Very mild lift. Left temple (10, 21, 54, 67, 103, 109, 162, 127): displacement (-0.5 * scale, -1.0 * scale). Right temple (284, 297, 332, 338, 323, 356, 389, 454): displacement (+0.5 * scale, -1.0 * scale). Reduced radius (0.6x). The forehead and temples are mostly untouched in a standard facelift.
@@ -64,7 +64,7 @@ Very mild lift. Left temple (10, 21, 54, 67, 103, 109, 162, 127): displacement (
 **Full landmark set (33 indices):**
 `10, 21, 54, 58, 67, 93, 103, 109, 127, 132, 136, 150, 162, 172, 176, 187, 207, 213, 234, 284, 297, 323, 332, 338, 356, 361, 365, 379, 389, 397, 400, 427, 454`
 
-**Clinical note:** The wide influence radius (40px) is intentional -- facelifts redistribute tissue broadly. Ehlers-Danlos clinical flag scales this to 60px for hypermobile tissue.
+**Clinical note:** The wide influence radius (40px) is intentional: facelifts redistribute tissue broadly. Ehlers-Danlos clinical flag scales this to 60px for hypermobile tissue.
 
 ---
 

--- a/docs/wiki/Quick-Start.md
+++ b/docs/wiki/Quick-Start.md
@@ -12,7 +12,7 @@ For GPU modes (img2img, controlnet, controlnet_ip), you also need a CUDA-capable
 
 ---
 
-## Mode 1: TPS (Thin Plate Spline) -- CPU, Instant
+## Mode 1: TPS (Thin Plate Spline): CPU, Instant
 
 The simplest mode. No GPU, no model downloads, no diffusion. Pure geometric warping.
 
@@ -39,7 +39,7 @@ cv2.imwrite("prediction_tps.png", result["output"])
 
 ---
 
-## Mode 2: img2img -- GPU, ~5 seconds
+## Mode 2: img2img: GPU, ~5 seconds
 
 Feeds the TPS-warped image into Stable Diffusion 1.5 img2img for texture refinement. The diffusion model only modifies the surgical region (via mask compositing).
 
@@ -66,7 +66,7 @@ cv2.imwrite("prediction_img2img.png", result["output"])
 
 ---
 
-## Mode 3: ControlNet -- GPU, ~8 seconds
+## Mode 3: ControlNet: GPU, ~8 seconds
 
 Renders the deformed face mesh as a wireframe and uses CrucibleAI/ControlNetMediaPipeFace to generate the face from conditioning. Best photorealistic quality.
 
@@ -93,7 +93,7 @@ cv2.imwrite("prediction_controlnet.png", result["output"])
 
 ---
 
-## Mode 4: ControlNet + IP-Adapter -- GPU, ~10 seconds
+## Mode 4: ControlNet + IP-Adapter: GPU, ~10 seconds
 
 Same as ControlNet, with the addition of h94/IP-Adapter-FaceID for identity-preserving generation. Conditions the diffusion model on an ArcFace embedding of the input face.
 
@@ -307,7 +307,7 @@ For a guided walkthrough with inline visualizations, see the [quickstart noteboo
 
 ## Next Steps
 
-- [Procedures](Procedures) -- detailed guide for each surgical procedure
-- [API Reference](API-Reference) -- full class and function documentation
-- [Architecture](Architecture) -- how the pipeline works internally
-- [Training](Training) -- how to train your own ControlNet
+- [Procedures](Procedures): detailed guide for each surgical procedure
+- [API Reference](API-Reference): full class and function documentation
+- [Architecture](Architecture): how the pipeline works internally
+- [Training](Training): how to train your own ControlNet

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -6,7 +6,7 @@
 
 **Fixes (try in order):**
 
-1. Use `tps` mode if you only need geometric warping -- no GPU needed at all.
+1. Use `tps` mode if you only need geometric warping: no GPU needed at all.
 
 2. The pipeline enables `model_cpu_offload()` by default, which should keep peak VRAM under 6 GB for ControlNet mode. If this still fails, check that no other process is using the GPU:
    ```bash

--- a/scripts/hf_space/README.md
+++ b/scripts/hf_space/README.md
@@ -9,7 +9,7 @@ python_version: "3.11"
 app_file: app.py
 pinned: true
 license: mit
-short_description: Facial surgery prediction -- 2D foundation toward 3D
+short_description: Facial surgery prediction, 2D foundation toward 3D
 tags:
   - medical-imaging
   - face
@@ -46,14 +46,14 @@ Upload a face photo, select a surgical procedure, adjust intensity, and see the 
 
 ## How It Works
 
-1. **MediaPipe landmarks** -- 478-point facial mesh extraction
-2. **Anatomical displacement** -- procedure-specific landmark shifts scaled by intensity (0-100)
-3. **TPS deformation** -- thin-plate spline warps the image smoothly
-4. **Masked compositing** -- blends the surgical region back into the original photo
+1. **MediaPipe landmarks**: 478-point facial mesh extraction
+2. **Anatomical displacement**: procedure-specific landmark shifts scaled by intensity (0-100)
+3. **TPS deformation**: thin-plate spline warps the image smoothly
+4. **Masked compositing**: blends the surgical region back into the original photo
 
 GPU modes (ControlNet, img2img) with photorealistic rendering are available in the full package.
 
-**Roadmap:** This 2D TPS demo is the foundation. Next up -- 3D face reconstruction from phone video for interactive surgical preview.
+**Roadmap:** This 2D TPS demo is the foundation. Next up: 3D face reconstruction from phone video for interactive surgical preview.
 
 ## Photo Tips
 


### PR DESCRIPTION
## Summary
- Replace ` -- ` (prose em dashes) with colons, commas, or periods across 32 documentation files
- Preserve table placeholder values (`| -- |`) and code blocks
- Fix ranged em dashes in README (`10--15%` to `10 to 15%`, `I--VI` to `I through VI`, citation page ranges to single hyphens)
- Fix mermaid diagram label

## Files changed
32 markdown files across docs/, wiki/, README, CHANGELOG, CONTRIBUTING, demos/, scripts/hf_space/

## Test plan
- [ ] Verify no broken table formatting
- [ ] Verify no broken code blocks
- [ ] Verify mermaid diagram renders correctly