### PR TITLE
Fix CI failures, add codecov config, update contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,8 @@ Thanks to everyone who has contributed to LandmarkDiff.
 | [P-r-e-m-i-u-m](https://github.com/P-r-e-m-i-u-m) | Mentoplasty procedure preset ([#36](https://github.com/dreamlessx/LandmarkDiff-public/pull/36)) |
 | [lshariprasad](https://github.com/lshariprasad) | histogram_match_skin tests ([#263](https://github.com/dreamlessx/LandmarkDiff-public/pull/263)) |
 | [dagangtj](https://github.com/dagangtj) | SafetyResult dataclass improvements ([#235](https://github.com/dreamlessx/LandmarkDiff-public/pull/235)), file logging handler ([#236](https://github.com/dreamlessx/LandmarkDiff-public/pull/236)), api_client error messages ([#237](https://github.com/dreamlessx/LandmarkDiff-public/pull/237)) |
+| [PredictiveManish](https://github.com/PredictiveManish) | OpenAPI specification ([#340](https://github.com/dreamlessx/LandmarkDiff-public/pull/340)), batch processing notebook ([#334](https://github.com/dreamlessx/LandmarkDiff-public/pull/334)) |
+| [srikar117](https://github.com/srikar117) | Dark mode for Gradio interface ([#204](https://github.com/dreamlessx/LandmarkDiff-public/issues/204), in progress) |
 | [passionworkeer](https://github.com/passionworkeer) | Docker architecture feedback ([#5](https://github.com/dreamlessx/LandmarkDiff-public/issues/5)) |
 
 ## Data Contributors

--- a/README.md
+++ b/README.md
@@ -1075,6 +1075,11 @@ We track all contributions and contributors will be acknowledged in the MICCAI 2
 | [@dreamlessx](https://github.com/dreamlessx) | Core architecture, training pipeline, paper |
 | [@Deepak8858](https://github.com/Deepak8858) | Brow lift procedure preset ([#35](https://github.com/dreamlessx/LandmarkDiff-public/pull/35)) |
 | [@P-r-e-m-i-u-m](https://github.com/P-r-e-m-i-u-m) | Mentoplasty procedure preset ([#36](https://github.com/dreamlessx/LandmarkDiff-public/pull/36)) |
+| [@PredictiveManish](https://github.com/PredictiveManish) | OpenAPI spec ([#340](https://github.com/dreamlessx/LandmarkDiff-public/pull/340)), batch notebook ([#334](https://github.com/dreamlessx/LandmarkDiff-public/pull/334)) |
+| [@lshariprasad](https://github.com/lshariprasad) | histogram_match_skin tests ([#263](https://github.com/dreamlessx/LandmarkDiff-public/pull/263)) |
+| [@dagangtj](https://github.com/dagangtj) | SafetyResult dataclass, file logging, API error messages ([#235](https://github.com/dreamlessx/LandmarkDiff-public/pull/235), [#236](https://github.com/dreamlessx/LandmarkDiff-public/pull/236), [#237](https://github.com/dreamlessx/LandmarkDiff-public/pull/237)) |
+| [@srikar117](https://github.com/srikar117) | Dark mode for Gradio interface ([#204](https://github.com/dreamlessx/LandmarkDiff-public/issues/204), in progress) |
+| [@passionworkeer](https://github.com/passionworkeer) | Docker architecture feedback ([#5](https://github.com/dreamlessx/LandmarkDiff-public/issues/5)) |
 
 To join this list, open a PR or contribute to an issue. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 73%
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+
+ignore:
+  - "scripts/**"
+  - "examples/**"
+  - "docs/**"
+  - "tests/**"

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,12 +1,17 @@
-openapi: 3.0.3
+openapi: "3.0.3"
 info:
   title: LandmarkDiff API
-  description: Surgical outcome prediction using landmark-conditioned diffusion
-  version: 0.2.0
-  contact:
-    name: LandmarkDiff Team
+  version: "0.2.0"
+  description: |
+    REST API for surgical outcome prediction using landmark-guided
+    diffusion models.  Accepts face images and returns predicted
+    post-surgical results with configurable procedure type and intensity.
   license:
-    name: Apache 2.0
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+  contact:
+    name: LandmarkDiff
+    url: https://github.com/dreamlessx/LandmarkDiff-public
 
 servers:
   - url: http://localhost:8000
@@ -16,184 +21,283 @@ paths:
   /health:
     get:
       summary: Health check
-      operationId: getHealth
+      operationId: healthCheck
+      tags: [system]
       responses:
-        200:
-          description: Service status
+        "200":
+          description: Server is healthy
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HealthResponse'
-              example:
-                status: ok
-                version: 0.2.0
-                neural: false
+                $ref: "#/components/schemas/HealthResponse"
 
   /procedures:
     get:
       summary: List available procedures
-      operationId: getProcedures
+      operationId: listProcedures
+      tags: [procedures]
       responses:
-        200:
-          description: List of procedures
+        "200":
+          description: List of supported surgical procedures
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProceduresResponse'
+                $ref: "#/components/schemas/ProcedureListResponse"
 
   /predict:
     post:
-      summary: Run full prediction pipeline
+      summary: Run surgical outcome prediction
       operationId: predict
+      tags: [prediction]
       requestBody:
         required: true
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PredictRequest'
+              type: object
+              required: [image]
+              properties:
+                image:
+                  type: string
+                  format: binary
+                  description: Input face image (JPEG, PNG, WebP, HEIC)
+                procedure:
+                  type: string
+                  default: rhinoplasty
+                  enum:
+                    - rhinoplasty
+                    - blepharoplasty
+                    - rhytidectomy
+                    - orthognathic
+                    - brow_lift
+                    - mentoplasty
+                    - alarplasty
+                    - canthoplasty
+                    - buccal_fat_removal
+                    - dimpleplasty
+                    - genioplasty
+                    - malarplasty
+                    - lip_lift
+                    - lip_augmentation
+                    - forehead_reduction
+                    - submental_liposuction
+                    - otoplasty
+                  description: Surgical procedure type
+                intensity:
+                  type: number
+                  format: float
+                  default: 65.0
+                  minimum: 0
+                  maximum: 100
+                  description: Modification intensity (0=none, 100=maximum)
+                seed:
+                  type: integer
+                  default: 42
+                  description: Random seed for reproducible results
+                mode:
+                  type: string
+                  default: tps
+                  enum: [tps, img2img, controlnet, controlnet_ip, controlnet_fast]
+                  description: |
+                    Inference mode:
+                    - tps: Pure geometric warp (CPU, instant)
+                    - img2img: SD1.5 img2img with mask compositing
+                    - controlnet: CrucibleAI ControlNet + SD1.5
+                    - controlnet_ip: ControlNet with IP-Adapter identity
+                    - controlnet_fast: ControlNet with LCM-LoRA (4 steps)
       responses:
-        200:
+        "200":
           description: Prediction result
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PredictResponse'
-        400:
-          $ref: '#/components/responses/BadRequest'
-        422:
-          $ref: '#/components/responses/NoFaceDetected'
+                $ref: "#/components/schemas/PredictionResponse"
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "422":
+          description: No face detected in image
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /analyze:
     post:
-      summary: Analyze face image
+      summary: Analyze face without generating prediction
       operationId: analyzeFace
+      tags: [analysis]
       requestBody:
         required: true
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/AnalyzeRequest'
+              type: object
+              required: [image]
+              properties:
+                image:
+                  type: string
+                  format: binary
+                  description: Input face image
       responses:
-        200:
-          description: Analysis result
+        "200":
+          description: Face analysis results
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AnalyzeResponse'
+                $ref: "#/components/schemas/AnalysisResponse"
+        "422":
+          description: No face detected
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /batch:
     post:
-      summary: Batch process multiple images
+      summary: Batch prediction on multiple images
       operationId: batchPredict
+      tags: [prediction]
       requestBody:
         required: true
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/BatchRequest'
+              type: object
+              required: [images]
+              properties:
+                images:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: Multiple input face images
+                procedure:
+                  type: string
+                  default: rhinoplasty
+                  description: Procedure to apply to all images
+                intensity:
+                  type: number
+                  format: float
+                  default: 65.0
+                  minimum: 0
+                  maximum: 100
+                seed:
+                  type: integer
+                  default: 42
       responses:
-        200:
-          description: Batch results
+        "200":
+          description: Batch prediction results
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BatchResponse'
+                $ref: "#/components/schemas/BatchResponse"
 
 components:
   schemas:
     HealthResponse:
       type: object
       properties:
-        status: { type: string, example: ok }
-        version: { type: string, example: 0.2.0 }
-        neural: { type: boolean, example: false }
+        status:
+          type: string
+          example: healthy
+        version:
+          type: string
+          example: "0.2.0"
+        device:
+          type: string
+          example: cuda
+        mode:
+          type: string
+          example: controlnet
+        procedures_available:
+          type: integer
+          example: 17
 
-    ProceduresResponse:
+    ProcedureListResponse:
       type: object
       properties:
         procedures:
           type: array
-          items: { type: string }
-          example: [rhinoplasty, blepharoplasty, rhytidectomy, orthognathic, brow_lift, mentoplasty]
-        default_intensity: { type: number, example: 65.0 }
-        intensity_range:
-          type: array
-          items: { type: number }
-          example: [0, 100]
+          items:
+            type: string
+          example:
+            - rhinoplasty
+            - blepharoplasty
+            - rhytidectomy
+            - orthognathic
+            - brow_lift
+            - mentoplasty
 
-    PredictRequest:
+    PredictionResponse:
       type: object
-      required: [image]
       properties:
-        image:
+        output_image:
           type: string
-          format: binary
-          description: Input face image (JPEG/PNG)
+          format: byte
+          description: Base64-encoded output image (PNG)
         procedure:
           type: string
-          default: rhinoplasty
-          enum: [rhinoplasty, blepharoplasty, rhytidectomy, orthognathic, brow_lift, mentoplasty]
+          example: rhinoplasty
         intensity:
           type: number
-          default: 65.0
-          minimum: 0
-          maximum: 100
-        return_intermediates:
-          type: boolean
-          default: false
-        return_format:
-          type: string
-          default: base64
-          enum: [base64, binary]
-
-    PredictResponse:
-      type: object
-      properties:
-        procedure: { type: string }
-        intensity: { type: number }
-        ssim: { type: number }
-        fitzpatrick: { type: string }
-        identity_check: { type: object }
-        elapsed_seconds: { type: number }
-        neural_postprocess: { type: boolean }
-        output: { type: string, description: base64 encoded image }
-
-    AnalyzeRequest:
-      type: object
-      required: [image]
-      properties:
-        image:
-          type: string
-          format: binary
-
-    AnalyzeResponse:
-      type: object
-      properties:
-        detected: { type: boolean }
-        num_landmarks: { type: integer }
-        image_size:
-          type: array
-          items: { type: integer }
-        confidence: { type: number }
-        fitzpatrick: { type: string }
-        view: { type: object }
-        landmarks_preview: { type: string }
-
-    BatchRequest:
-      type: object
-      required: [images]
-      properties:
-        images:
+          example: 65.0
+        confidence:
+          type: number
+          description: Face detection confidence (0-1)
+          example: 0.95
+        view_info:
+          $ref: "#/components/schemas/ViewInfo"
+        quality_warnings:
           type: array
           items:
             type: string
-            format: binary
-        procedure:
-          type: string
-          default: rhinoplasty
-        intensity:
+          description: Input quality warnings (empty if good)
+        metrics:
+          type: object
+          additionalProperties:
+            type: number
+          description: Optional quality metrics
+        metadata:
+          type: object
+          additionalProperties: true
+
+    AnalysisResponse:
+      type: object
+      properties:
+        landmarks:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+            minItems: 3
+            maxItems: 3
+          description: "478 landmarks as [x, y, z] normalized coordinates"
+        confidence:
           type: number
-          default: 65.0
+          example: 0.95
+        view_info:
+          $ref: "#/components/schemas/ViewInfo"
+        fitzpatrick_type:
+          type: string
+          enum: [I, II, III, IV, V, VI]
+          description: Estimated Fitzpatrick skin type
+        measurements:
+          type: object
+          properties:
+            goode_ratio:
+              type: number
+              description: Nasal projection/length ratio
+            nasofrontal_angle:
+              type: number
+              description: Nasofrontal angle in degrees
+            canthal_tilt:
+              type: number
+              description: Mean canthal tilt in degrees
 
     BatchResponse:
       type: object
@@ -201,32 +305,47 @@ components:
         results:
           type: array
           items:
-            type: object
-            properties:
-              filename: { type: string }
-              success: { type: boolean }
-              output: { type: string }
-              ssim: { type: number }
-              error: { type: string }
-        total: { type: integer }
+            $ref: "#/components/schemas/PredictionResponse"
+        total:
+          type: integer
+          description: Total number of images processed
+        successful:
+          type: integer
+          description: Number of successful predictions
+        failed:
+          type: integer
+          description: Number of failed predictions
 
-  responses:
-    BadRequest:
-      description: Invalid request parameters
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              detail: { type: string }
-    NoFaceDetected:
-      description: No face detected in image
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              detail: { type: string }
+    ViewInfo:
+      type: object
+      properties:
+        yaw:
+          type: number
+          description: Estimated yaw angle in degrees
+          example: 2.5
+        pitch:
+          type: number
+          description: Estimated pitch angle in degrees
+          example: -3.1
+        view:
+          type: string
+          enum: [frontal, three_quarter, profile]
+          example: frontal
+        is_frontal:
+          type: boolean
+          example: true
+        warning:
+          type: string
+          nullable: true
+          description: View-related warning message
+
+    ErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+          description: Error message
+          example: No face detected in image
 
   securitySchemes:
     ApiKeyAuth:

--- a/landmarkdiff/health.py
+++ b/landmarkdiff/health.py
@@ -231,7 +231,7 @@ def check_gpu() -> CheckResult:
         available = torch.cuda.is_available()
         if available:
             name = torch.cuda.get_device_name(0)
-            vram_gb = torch.cuda.get_device_properties(0).total_mem / 1e9
+            vram_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
             return CheckResult(
                 name="gpu",
                 healthy=True,


### PR DESCRIPTION
## Summary
- Fix mypy type-check failure: `total_mem` -> `total_memory` (PyTorch 2.10+ API rename)
- Expand OpenAPI spec with all 17 procedures, proper schema names (`PredictionResponse`, `ErrorResponse`, `ViewInfo`), and complete field definitions. Builds on PredictiveManish's initial spec (#340)
- Add `codecov.yml` with 73% project target, 80% patch target
- Update contributor lists in README and CONTRIBUTORS.md (added PredictiveManish, srikar117, dagangtj)

## Test plan
- [x] `test_openapi.py`: all 15 tests pass locally
- [ ] CI lint, type-check, test (3.10/3.11/3.12)