### PR TITLE
Fix insecure 0.0.0.0 server bindings

### DIFF
--- a/scripts/app.py
+++ b/scripts/app.py
@@ -691,7 +691,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="LandmarkDiff Interactive UI")
     parser.add_argument("--port", type=int, default=7860)
     parser.add_argument("--share", action="store_true", help="Create public Gradio link")
-    parser.add_argument("--server-name", default="0.0.0.0")
+    parser.add_argument("--server-name", default="127.0.0.1")
     args = parser.parse_args()
 
     app = build_app()

--- a/scripts/demo_server.py
+++ b/scripts/demo_server.py
@@ -377,7 +377,7 @@ def main():
     )
     parser.add_argument("--port", type=int, default=7860, help="Server port")
     parser.add_argument("--share", action="store_true", help="Create a public Gradio share link")
-    parser.add_argument("--server-name", default="0.0.0.0", help="Server host address")
+    parser.add_argument("--server-name", default="127.0.0.1", help="Server host address")
     args = parser.parse_args()
 
     print("=" * 60)


### PR DESCRIPTION
Changes default server binding from 0.0.0.0 (all interfaces) to 127.0.0.1 (localhost only) in demo_server.py and app.py. Part of security cleanup for issue #370.