### PR TITLE
feat: add dark mode toggle to Gradio app

### DIFF
--- a/scripts/app.py
+++ b/scripts/app.py
@@ -281,7 +281,8 @@ def build_app():
             () => {
                 const url = new URL(window.location.href);
                 const current = url.searchParams.get('__theme');
-                url.searchParams.set('__theme', (!current || current === 'light') ? 'dark' : 'light');
+                const next = (!current || current === 'light') ? 'dark' : 'light');
+                url.searchParams.set('__theme', next);
                 window.location.href = url.toString();
             }
             """,


### PR DESCRIPTION
## Description

Brief summary of what this PR does and why.

Adds a dark/light mode toggle button to the Gradio demo (`scripts/app.py`).
The button is fixed to the top-right corner and uses Gradio's native `?__theme` URL param to switch themes. Also adds dark-mode-aware CSS for `.side-by-side img` borders.

Fixes #204 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] New procedure preset
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Tests or CI

## Changes

- Added `custom_css` with `@media (prefers-color-scheme: dark)` variant for `.side-by-side img`
- Passed `css=custom_css` explicitly to `gr.Blocks()`
- Added 🌙 Dark / ☀️ Light toggle button fixed to top-right via `position: fixed` CSS

## Testing

- [ ] `ruff check landmarkdiff/ scripts/ tests/` passes
- [ ] `mypy landmarkdiff/ --ignore-missing-imports` passes
- [ ] `pytest tests/` passes
- [ ] New tests added for new functionality (if applicable)

## Screenshots / outputs

If applicable, add before/after images or sample outputs.
Dark Mode
<img width="1369" height="726" alt="Screenshot 2026-03-16 at 8 08 03 PM" src="https://github.com/user-attachments/assets/00db85fc-63a2-4f1b-bb71-11b4f557c03f" />

Light Mode
<img width="1370" height="728" alt="Screenshot 2026-03-16 at 8 08 16 PM" src="https://github.com/user-attachments/assets/8f9efeae-1b99-432f-b064-a582c34d6232" />

## Checklist

- [x] My code follows the project's style (ruff, 100 char line length)
- [ ] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
